### PR TITLE
Prevent incompatible arm64e release builds

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.dangkhoa.hotspotpro
 Name: HotspotPro
-Version: 0.6.6
+Version: 0.6.7
 Architecture: iphoneos-arm64
 Description: See how much data your Personal Hotspot has shared, who is using it, and cap them.
 Maintainer: DangKhoa <dangkhoa116@gmail.com>

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,84 +1,12 @@
 #!/usr/bin/env bash
-# Build the release set: one .deb per jailbreak type, each fat with both
-# architectures. Run as builder.
-#   wsl -d Ubuntu -u builder -- bash /mnt/c/Users/DangKhoa/HotspotPro/tools/build-release.sh
-#
-# Why two packages:
-#   rootless (Architecture: iphoneos-arm64) — Dopamine, palera1n rootless, Xina
-#   rootful  (Architecture: iphoneos-arm)   — unc0ver, checkra1n, palera1n rootful
-# and why both architectures in each: arm64 covers A7-A11, arm64e covers A12 and
-# newer, whose system processes a purely arm64 dylib cannot be injected into.
-
-export THEOS="$HOME/theos"
-export PATH="$THEOS/toolchain/linux/host/bin:$PATH"
-
-SRC=/mnt/c/Users/DangKhoa/HotspotPro
-LOG="$SRC/build-release.log"
-exec > >(tee "$LOG") 2>&1
-echo "=== release build started $(date) ==="
-
-WORK="$HOME/HotspotPro-release"
-rm -rf "$WORK"
-mkdir -p "$WORK"
-# Sources live in src/ but land FLAT in the build dir, so the Makefile keeps
-# naming them bare. Do not "fix" that by adding src/ prefixes in the Makefile.
-cp -f "$SRC"/src/*.m "$SRC"/src/*.h "$SRC"/src/*.x "$WORK"/ 2>/dev/null
-cp -f "$SRC"/Makefile "$SRC"/control "$SRC"/*.plist "$WORK"/ 2>/dev/null
-
-# Turn the tip-jar link into a header. Generated rather than passed as a -D:
-# the URL contains '&', which make and the shell between them mangle.
-if [ -s "$SRC/donate-url.txt" ]; then
-    printf '#define HP_DONATE_URL "%s"\n' "$(cat "$SRC/donate-url.txt")" > "$WORK/DonateURL.h"
-    echo "tip jar: $(cat "$SRC/donate-url.txt")"
-else
-    rm -f "$WORK/DonateURL.h"
-    echo "tip jar: not configured, row will be hidden"
-fi
-cp -r "$SRC"/layout "$WORK"/
-chmod 755 "$WORK"/layout/DEBIAN/postinst "$WORK"/layout/DEBIAN/prerm
-
-OUT="$SRC/release"
-mkdir -p "$OUT"
-rm -f "$OUT"/*.deb
-
-build_scheme() {
-    local scheme="$1" label="$2"
-    echo
-    echo "=== building $label ==="
-    cd "$WORK"
-    rm -rf .theos packages          # 'make clean' hangs under WSL1
-
-    # The Architecture field is what tells package managers which jailbreak a
-    # deb is for, and Theos takes it verbatim from control rather than from the
-    # scheme. Left alone, the rootful build produces a second iphoneos-arm64
-    # package that overwrites the rootless one.
-    if [ "$scheme" = "rootful" ]; then
-        sed -i 's/^Architecture: .*/Architecture: iphoneos-arm/' control
-        make package FINALPACKAGE=1 HP_ROOTFUL=1 -j1
-    else
-        sed -i 's/^Architecture: .*/Architecture: iphoneos-arm64/' control
-        make package FINALPACKAGE=1 -j1
-    fi
-
-    local rc=$?
-    if [ $rc -ne 0 ]; then
-        echo "!! $label FAILED (exit $rc)"
-        return $rc
-    fi
-    cp -f packages/*.deb "$OUT"/
-    return 0
-}
-
-build_scheme "rootless" "rootless (iphoneos-arm64)" || exit 1
-build_scheme "rootful" "rootful (iphoneos-arm)" || exit 1
-
-echo
-echo "=== release artifacts ==="
-ls -la "$OUT"
-for deb in "$OUT"/*.deb; do
-    echo
-    echo "--- $(basename "$deb") ---"
-    dpkg-deb -f "$deb" Package Version Architecture Depends
-    echo "payload:"
-    dpkg-deb -c "$deb" | grep -E 'DynamicLibraries|libexec|usr/bin' | sed 's/^/  /'
+# Both jailbreak layouts use the same build and ABI verification pipeline.
+set -euo pipefail
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="$(awk '/^Version:/{print $2}' "$SRC/control")"
+mkdir -p "$SRC/release"
+for rootful in 0 1; do
+    HP_ROOTFUL="$rootful" bash "$SRC/tools/build.sh" "$@"
+    arch=iphoneos-arm64
+    [ "$rootful" = 0 ] || arch=iphoneos-arm
+    cp "$SRC/packages/com.dangkhoa.hotspotpro_${VERSION}_${arch}.deb" "$SRC/release/"
 done

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,59 +1,36 @@
 #!/usr/bin/env bash
-# Builds the HotspotPro .deb. Run as builder.
-#   wsl -d Ubuntu -u builder -- bash /mnt/c/Users/DangKhoa/HotspotPro/tools/build.sh
-
-export THEOS="$HOME/theos"
-export PATH="$THEOS/toolchain/linux/host/bin:$PATH"
-
-# Write our own log so output survives regardless of how the caller captures it.
-LOG=/mnt/c/Users/DangKhoa/HotspotPro/build.log
-exec > >(tee "$LOG") 2>&1
-echo "=== build started $(date) ==="
-
-echo '=== toolchain ==='
-"$THEOS/toolchain/linux/iphone/bin/clang" --version 2>/dev/null | head -1 || echo 'clang MISSING'
-echo
-echo '=== sdks ==='
-ls "$THEOS/sdks"
-echo
-echo '=== building ==='
-# Build in a Linux-native dir: Theos + WSL1 on a /mnt/c DrvFs path hits
-# permission and symlink problems, so copy the sources across first.
-SRC=/mnt/c/Users/DangKhoa/HotspotPro
-WORK="$HOME/HotspotPro"
-mkdir -p "$WORK"
-# Sources live in src/ but are copied FLAT into the build dir, which is why the
-# Makefile still names them bare (Tweak.x, Collector.m, ...). Keep it that way:
-# the flattening is what lets the tree be organised without touching Theos.
-cp -f "$SRC"/src/*.m "$SRC"/src/*.h "$SRC"/src/*.x "$WORK"/ 2>/dev/null
-cp -f "$SRC"/Makefile "$SRC"/control "$SRC"/*.plist "$WORK"/ 2>/dev/null
+# Build in a temporary native filesystem directory, keeping source names flat.
+set -euo pipefail
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+export THEOS="${THEOS:-$HOME/theos}"
+if [ "$(uname -s)" = Linux ]; then
+    export PATH="$THEOS/toolchain/linux/host/bin:$PATH"
+fi
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/hotspotpro-build.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+export CLANG_MODULE_CACHE_PATH="${CLANG_MODULE_CACHE_PATH:-$WORK/module-cache}"
+cp "$SRC"/src/*.m "$SRC"/src/*.h "$SRC"/src/*.x "$WORK/"
+cp "$SRC/Makefile" "$SRC/control" "$SRC"/*.plist "$WORK/"
+cp -R "$SRC/layout" "$WORK/"
+chmod 755 "$WORK/layout/DEBIAN/postinst" "$WORK/layout/DEBIAN/prerm"
 if [ -s "$SRC/donate-url.txt" ]; then
-    printf '#define HP_DONATE_URL "%s"\n' "$(cat "$SRC/donate-url.txt")" > "$WORK/DonateURL.h"
-else
-    rm -f "$WORK/DonateURL.h"
+    python3 - "$SRC/donate-url.txt" "$WORK/DonateURL.h" <<'PY'
+import json, pathlib, sys
+url = pathlib.Path(sys.argv[1]).read_text().strip()
+pathlib.Path(sys.argv[2]).write_text('#define HP_DONATE_URL ' + json.dumps(url) + '\n')
+PY
 fi
-# layout/ carries the LaunchDaemon plist and the DEBIAN maintainer scripts.
-rm -rf "$WORK/layout"
-cp -r "$SRC"/layout "$WORK"/ 2>/dev/null
-chmod 755 "$WORK"/layout/DEBIAN/postinst "$WORK"/layout/DEBIAN/prerm 2>/dev/null
-cd "$WORK"
-
-# NOTE: 'make clean' hangs under WSL 1 here, so wipe the build dirs directly
-# instead. Same effect, no stall.
-rm -rf .theos packages
-
-make package FINALPACKAGE=1 -j1 2>&1
-RC=$?
-echo
-echo "make exit=$RC"
-echo '=== packages ==='
-ls -la "$WORK/packages" 2>/dev/null || echo '(none)'
-
-# Copy any built deb back to the Windows side
-if ls "$WORK"/packages/*.deb >/dev/null 2>&1; then
-    mkdir -p "$SRC/packages"
-    cp -f "$WORK"/packages/*.deb "$SRC/packages/"
-    echo "copied to $SRC/packages/"
-    ls -la "$SRC/packages/"
+if [ "${HP_ROOTFUL:-0}" = 1 ]; then
+    python3 - "$WORK/control" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1])
+p.write_text(p.read_text().replace('Architecture: iphoneos-arm64', 'Architecture: iphoneos-arm'))
+PY
 fi
-exit $RC
+# Serial make also avoids hangs in the older make shipped with Xcode.
+make -C "$WORK" all FINALPACKAGE=1 "$@" -j1
+python3 "$SRC/tools/check-arm64e.py" "$WORK"/.theos/obj/HotspotPro*.dylib \
+    "$WORK/.theos/obj/hotspotpro" "$WORK/.theos/obj/hotspotprod"
+make -C "$WORK" package FINALPACKAGE=1 "$@" -j1
+mkdir -p "$SRC/packages"
+cp "$WORK"/packages/*.deb "$SRC/packages/"

--- a/tools/check-arm64e.py
+++ b/tools/check-arm64e.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Reject legacy arm64e ABI binaries before packaging iOS 14+ tweaks."""
+import struct
+import sys
+from pathlib import Path
+
+
+def check(path):
+    data = Path(path).read_bytes()
+    if data[:4] == b'\xca\xfe\xba\xbe':
+        count = struct.unpack_from('>I', data, 4)[0]
+        slices = [struct.unpack_from('>IIIII', data, 8 + 20 * i)
+                  for i in range(count)]
+    else:
+        raise ValueError('expected a universal Mach-O with arm64 and arm64e')
+    found = set()
+    for cpu, subtype, offset, size, _ in slices:
+        if offset + size > len(data) or size < 32:
+            raise ValueError('invalid Mach-O slice bounds')
+        magic, actual_cpu, actual_subtype = struct.unpack_from('<III', data, offset)
+        if (magic, actual_cpu, actual_subtype) != (0xFEEDFACF, cpu, subtype):
+            raise ValueError('fat header and Mach-O slice disagree')
+        if cpu == 0x0100000C:
+            found.add(subtype & 0x00FFFFFF)
+            if subtype & 0x00FFFFFF == 2 and not subtype & 0x80000000:
+                raise ValueError('legacy arm64e ABI: rebuild with a modern Apple toolchain; '
+                                 'this binary crashes during loading on iOS 14+')
+    if not {0, 2}.issubset(found):
+        raise ValueError('both arm64 and arm64e slices are required')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        sys.exit('usage: check-arm64e.py binary [...]')
+    failed = False
+    for name in sys.argv[1:]:
+        try:
+            check(name)
+            print(f'PASS {name}')
+        except (OSError, ValueError, struct.error) as error:
+            print(f'FAIL {name}: {error}', file=sys.stderr)
+            failed = True
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
HotspotPro 0.6.6 crashes Settings while loading on newer arm64e devices because the packaged dylib uses the legacy arm64e ABI.

This change:

- rejects legacy arm64e binaries before packaging
- verifies both arm64 and modern arm64e slices
- makes the build scripts work from any checkout path on macOS and Linux
- uses the same verified build process for rootless and rootful packages
- bumps the package version to 0.6.7

Validated on an iPhone 14 Pro Max running iOS 16.5 with Dopamine. Settings opens successfully, the usage and device pages load, the background collector runs, and the on-device self-tests pass.