### PR TITLE
Stop reporting connected devices as offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ means a reset can never race a sample.
   tethering. Measured on-device: `bridge100` counts every forwarded packet
   *twice*, so counting the bridge would double your usage.
 - **Device names** — `/var/db/dhcpd_leases`, the hotspot's own DHCP records.
-- **Who is connected** — the ARP table, filtered to the hotspot subnet.
+- **Who is connected** — the ARP table, filtered to the hotspot subnet, minus
+  the clients that have left. ARP only ever records that a device *was* here, so
+  a departure is inferred from three independent signals going quiet together:
+  the daemon's packet tap, the kernel's ARP expiry and the DHCP lease end. The
+  window is minutes, because an idle client is silent for minutes — a
+  thirty-second one reported connected devices as offline and back again.
 - **Per-device bytes** — a BPF tap on the tethering bridge with a 14-byte snap
   length, so the kernel copies only each frame's Ethernet header while the
   frame's true length is still counted. Reads are batched; with the hotspot off

--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ means a reset can never race a sample.
   *twice*, so counting the bridge would double your usage.
 - **Device names** — `/var/db/dhcpd_leases`, the hotspot's own DHCP records.
 - **Who is connected** — the ARP table, filtered to the hotspot subnet, minus
-  the clients that have left. ARP only ever records that a device *was* here, so
-  a departure is inferred from three independent signals going quiet together:
-  the daemon's packet tap, the kernel's ARP expiry and the DHCP lease end. The
-  window is minutes, because an idle client is silent for minutes — a
-  thirty-second one reported connected devices as offline and back again.
+  the clients that have left. ARP only ever records that a device *was* here, and
+  waiting to overhear a client cannot tell "gone" from "idle": a connected device
+  with its screen off is entitled to say nothing for minutes, and a
+  thirty-second window reported those as offline and back again. So the daemon
+  **asks** — one unicast ARP request per client every 10s, sent through the tap
+  it already has open, skipping any client that has spoken since the last flush.
+  A device that is still associated answers in milliseconds. Silence in the face
+  of four unanswered questions is a departure; the window is 45s. If the tap
+  cannot be opened for writing the daemon says so, no probes go out, and the
+  window widens to four minutes — the passive rule, still corroborated by the
+  kernel's ARP expiry and the DHCP lease end.
 - **Per-device bytes** — a BPF tap on the tethering bridge with a 14-byte snap
   length, so the kernel copies only each frame's Ethernet header while the
   frame's true length is still counted. Reads are batched; with the hotspot off
@@ -62,7 +68,10 @@ Everything stays on the device. Nothing is uploaded anywhere.
 
 The daemon reads packet **headers** on the tethering bridge to attribute bytes
 to devices — it captures 14 bytes per frame, which is the Ethernet header, and
-never packet contents. It stores client MAC addresses, the names those devices
+never packet contents. It also sends one 42-byte ARP request to each connected
+client every 10s to ask whether it is still there, which is what every router's
+device list does; nothing is broadcast, nothing leaves the hotspot's own subnet,
+and those frames are excluded from your usage totals. It stores client MAC addresses, the names those devices
 announce over DHCP, and byte counts, in
 `/var/mobile/Library/Caches/hotspotpro-*.plist`. Device records are forgotten
 after 45 days. Switching **Track Hotspot Usage** off closes the tap entirely.

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.dangkhoa.hotspotpro
 Name: HotspotPro
-Version: 0.6.7
+Version: 0.6.8~beta5
 Architecture: iphoneos-arm64
 Description: See how much data your Personal Hotspot has shared, who is using it, and cap them.
 Maintainer: DangKhoa <dangkhoa116@gmail.com>

--- a/layout/DEBIAN/prerm
+++ b/layout/DEBIAN/prerm
@@ -22,5 +22,6 @@ launchctl unload "$PREFIX/Library/LaunchDaemons/com.dangkhoa.hotspotpro.plist" >
 
 rm -f /var/mobile/Library/Caches/hotspotpro-blocklist.plist
 rm -f /var/mobile/Library/Caches/hotspotpro-installed.plist
+rm -f /var/mobile/Library/Caches/hotspotpro-daemon.plist
 
 exit 0

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -122,6 +122,14 @@ BOOL HPHotspotIsActive(NSArray<NSDictionary *> *ifaces);
 /// not running, so callers must treat absence as "unknown", not "gone".
 NSDictionary<NSString *, NSDate *> *HPCopyDaemonLastSeen(void);
 
+/// When the daemon's current packet tap was opened, or nil when it has none.
+///
+/// Silence only means something once the tap has been listening for longer than
+/// the silence being interpreted: the tap closes and reopens whenever the
+/// tethering bridge flaps, and every per-client timestamp is stale for a while
+/// afterwards through no fault of the clients.
+NSDate *HPDaemonTapSince(void);
+
 /// When the daemon last wrote its counters — every 10s while its tap is open,
 /// whether or not any traffic arrived. This is the heartbeat that says "the
 /// silence of a given client means something", which per-client timestamps
@@ -187,6 +195,43 @@ NSArray<NSDictionary *> *HPCopyDhcpLeases(void);
 /// Devices connected right now: ARP neighbours on the hotspot interfaces,
 /// joined to lease records by MAC so they carry a name where one is known.
 NSArray<NSDictionary *> *HPCopyConnectedDevices(NSArray<NSString *> *hotspotIfNames);
+
+/// The same list with the devices that have actually left taken out.
+///
+/// HPCopyConnectedDevices() reports what the ARP table claims, and the ARP
+/// table only ever records that a client *was* here: a departed device's entry
+/// stops being refreshed and sits there counting down for the rest of its
+/// lifetime. This is the function to ask "who is connected right now".
+///
+/// A device stays on the list unless three independent signals all say nothing
+/// has been heard from it — the root daemon's packet tap, the kernel's ARP
+/// expiry, and the DHCP lease end — for several minutes running, and even then
+/// only once the tap has demonstrably been listening for that whole span. An
+/// idle client is silent for minutes at a time, so anything less flickers.
+///
+/// Keeps a little per-process state, so successive calls are what makes it
+/// work; calls within the same second share one answer, which is what keeps
+/// every row of a pane agreeing with the count above it.
+NSArray<NSDictionary *> *HPCopyPresentDevices(NSArray<NSString *> *hotspotIfNames);
+
+// The thresholds the rule above turns on, exposed so a test can express itself
+// in terms of them rather than restating the numbers.
+extern const NSTimeInterval HPSilentCutoff;      // unheard this long -> gone
+extern const NSTimeInterval HPDaemonStaleAfter;  // heartbeat older than this means nothing
+extern const int HPMissesNeeded;                 // consecutive silent polls before dropping
+
+/// The presence rule itself, with every input passed in.
+///
+/// Split out from HPCopyPresentDevices() so it can be exercised without a
+/// hotspot, a daemon or a clock: `hotspotpro selftest` drives it. `books` holds
+/// what the rule remembers between polls — an empty mutable dictionary on the
+/// first call, the same one thereafter — and `now` is the moment being judged.
+NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
+                                                NSDictionary<NSString *, NSDate *> *lastSeen,
+                                                NSDate *tapSince,
+                                                NSDate *lastFlush,
+                                                NSMutableDictionary *books,
+                                                NSDate *now);
 
 #pragma mark - Helpers
 

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -136,6 +136,15 @@ NSDate *HPDaemonTapSince(void);
 /// be judged on a much shorter window when this is true.
 BOOL HPDaemonIsProbing(void);
 
+/// The client MACs the daemon has an active reject route installed for, as of
+/// its last flush. This is what is *actually* enforced, which is not the same
+/// as what the tracker decided should be blocked: they diverge when the daemon
+/// is not running or cannot write routes, and a caller that wants to tell a
+/// device the truth about its own status must check this, not only the
+/// tracker's blocklist. Pair it with HPDaemonLastFlush() to know how current
+/// it is. Empty when the daemon has never run.
+NSArray<NSString *> *HPDaemonBlockedMacs(void);
+
 /// When the daemon last wrote its counters — every 10s while its tap is open,
 /// whether or not any traffic arrived. This is the heartbeat that says "the
 /// silence of a given client means something", which per-client timestamps

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -136,6 +136,13 @@ NSDate *HPDaemonTapSince(void);
 /// be judged on a much shorter window when this is true.
 BOOL HPDaemonIsProbing(void);
 
+/// The daemon's own breadcrumb: what it is doing and why, or nil when it has
+/// never run. Keys: "state" (NSString — "gated-ios18", "tracking-off",
+/// "no-bpf", "hotspot-off", "running", "running-noprobe", "starting"), "pid",
+/// "firmware", and "updated" (NSDate). Nil is itself an answer: the LaunchDaemon
+/// never bootstrapped, or the device refused to exec the binary.
+NSDictionary *HPCopyDaemonStatus(void);
+
 /// The client MACs the daemon has an active reject route installed for, as of
 /// its last flush. This is what is *actually* enforced, which is not the same
 /// as what the tracker decided should be blocked: they diverge when the daemon

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -130,6 +130,12 @@ NSDictionary<NSString *, NSDate *> *HPCopyDaemonLastSeen(void);
 /// afterwards through no fault of the clients.
 NSDate *HPDaemonTapSince(void);
 
+/// Whether the daemon is actively probing its clients — sending each one a
+/// unicast ARP request every 10s — rather than only listening. It answers a
+/// question the network cannot be relied on to answer unasked, so presence can
+/// be judged on a much shorter window when this is true.
+BOOL HPDaemonIsProbing(void);
+
 /// When the daemon last wrote its counters — every 10s while its tap is open,
 /// whether or not any traffic arrived. This is the heartbeat that says "the
 /// silence of a given client means something", which per-client timestamps
@@ -205,9 +211,14 @@ NSArray<NSDictionary *> *HPCopyConnectedDevices(NSArray<NSString *> *hotspotIfNa
 ///
 /// A device stays on the list unless three independent signals all say nothing
 /// has been heard from it — the root daemon's packet tap, the kernel's ARP
-/// expiry, and the DHCP lease end — for several minutes running, and even then
-/// only once the tap has demonstrably been listening for that whole span. An
-/// idle client is silent for minutes at a time, so anything less flickers.
+/// expiry, and the DHCP lease end — for the whole window running, and even then
+/// only once the tap has demonstrably been listening for that span.
+///
+/// The window is 45s while the daemon is probing, because then silence is
+/// silence in the face of four unanswered ARP requests. With no probes going
+/// out it widens to four minutes: an idle client is entitled to say nothing for
+/// minutes at a time, and anything shorter reports connected devices as
+/// offline and back again.
 ///
 /// Keeps a little per-process state, so successive calls are what makes it
 /// work; calls within the same second share one answer, which is what keeps
@@ -216,7 +227,8 @@ NSArray<NSDictionary *> *HPCopyPresentDevices(NSArray<NSString *> *hotspotIfName
 
 // The thresholds the rule above turns on, exposed so a test can express itself
 // in terms of them rather than restating the numbers.
-extern const NSTimeInterval HPSilentCutoff;      // unheard this long -> gone
+extern const NSTimeInterval HPSilentCutoff;       // unheard this long -> gone
+extern const NSTimeInterval HPSilentCutoffProbed;// ...and this long, while probing
 extern const NSTimeInterval HPDaemonStaleAfter;  // heartbeat older than this means nothing
 extern const int HPMissesNeeded;                 // consecutive silent polls before dropping
 
@@ -230,6 +242,7 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
                                                 NSDictionary<NSString *, NSDate *> *lastSeen,
                                                 NSDate *tapSince,
                                                 NSDate *lastFlush,
+                                                BOOL probing,
                                                 NSMutableDictionary *books,
                                                 NSDate *now);
 

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -728,6 +728,12 @@ NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
+NSDictionary *HPCopyDaemonStatus(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-daemon.plist"];
+    return [file isKindOfClass:[NSDictionary class]] ? file : nil;
+}
+
 NSArray<NSString *> *HPDaemonBlockedMacs(void) {
     NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
                               @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -535,7 +535,8 @@ NSArray<NSDictionary *> *HPCopyConnectedDevices(NSArray<NSString *> *hotspotIfNa
 #pragma mark - Presence
 
 // How long a client may go completely unheard — no captured frame, no ARP
-// refresh, no lease renewal — before it is treated as gone.
+// refresh, no lease renewal — before it is treated as gone, when nobody is
+// asking it anything.
 //
 // Minutes rather than seconds, because an idle client really is silent for
 // minutes. Nothing obliges an associated device sitting in a pocket with its
@@ -548,6 +549,14 @@ NSArray<NSDictionary *> *HPCopyConnectedDevices(NSArray<NSString *> *hotspotIfNa
 // really has left lingers for a few minutes; showing a present device as
 // offline is the worse of the two errors.
 const NSTimeInterval HPSilentCutoff = 240.0;
+
+// The same question, when the daemon is probing: it sends each client a unicast
+// ARP request every 10s and a client that is still associated answers in
+// milliseconds. Silence then means silence in the face of four unanswered
+// questions, not merely a device with nothing to say — which is both quicker
+// and more certain than the passive window above. Used only while the daemon
+// reports that its probes are actually going out.
+const NSTimeInterval HPSilentCutoffProbed = 45.0;
 
 // How stale the daemon's own heartbeat may be before its silence stops meaning
 // anything. It flushes every 10s while its tap is open, whether or not any
@@ -583,8 +592,10 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
                                                 NSDictionary<NSString *, NSDate *> *lastSeen,
                                                 NSDate *tapSince,
                                                 NSDate *lastFlush,
+                                                BOOL probing,
                                                 NSMutableDictionary *books,
                                                 NSDate *now) {
+    const NSTimeInterval cutoff = probing ? HPSilentCutoffProbed : HPSilentCutoff;
     NSMutableDictionary *lastExpire = HPBook(books, kHPBookExpire);
     NSMutableDictionary *lastLease  = HPBook(books, kHPBookLease);
     NSMutableDictionary *lastProof  = HPBook(books, kHPBookProof);
@@ -600,7 +611,7 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
     // departure may be inferred until the tap has been open for the whole
     // window it is being asked to interpret.
     BOOL canProveDeparture = beating && lastSeen.count > 0 && tapSince &&
-        [now timeIntervalSinceDate:tapSince] >= HPSilentCutoff;
+        [now timeIntervalSinceDate:tapSince] >= cutoff;
 
     NSMutableArray *present = [NSMutableArray array];
     NSMutableSet<NSString *> *live = [NSMutableSet set];
@@ -613,7 +624,7 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
         // of this client within the window. It sees sent frames too, so a
         // client that only receives still counts.
         NSDate *seen = lastSeen[mac];
-        BOOL heard = seen && [now timeIntervalSinceDate:seen] <= HPSilentCutoff;
+        BOOL heard = seen && [now timeIntervalSinceDate:seen] <= cutoff;
 
         // Evidence 2: the kernel pushed this ARP entry's expiry further out,
         // which it only does having heard from the neighbour. Compared against
@@ -657,9 +668,8 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
         int m = [misses[mac] intValue] + 1;
         misses[mac] = @(m);
         NSDate *proof = lastProof[mac];
-        NSTimeInterval quiet = proof ? [now timeIntervalSinceDate:proof]
-                                     : HPSilentCutoff;
-        if (m >= HPMissesNeeded && quiet >= HPSilentCutoff) continue;
+        NSTimeInterval quiet = proof ? [now timeIntervalSinceDate:proof] : cutoff;
+        if (m >= HPMissesNeeded && quiet >= cutoff) continue;
         [present addObject:dev];
     }
 
@@ -699,6 +709,7 @@ NSArray<NSDictionary *> *HPCopyPresentDevices(NSArray<NSString *> *hotspotIfName
                                    HPCopyDaemonLastSeen(),
                                    HPDaemonTapSince(),
                                    HPDaemonLastFlush(),
+                                   HPDaemonIsProbing(),
                                    books,
                                    now);
         cached    = [present copy];
@@ -715,6 +726,12 @@ NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
                               @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
     NSDictionary *bytes = file[@"bytesByMac"];
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
+}
+
+BOOL HPDaemonIsProbing(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    return [file[@"probing"] boolValue];
 }
 
 NSDate *HPDaemonTapSince(void) {

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -595,7 +595,15 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
                                                 BOOL probing,
                                                 NSMutableDictionary *books,
                                                 NSDate *now) {
-    const NSTimeInterval cutoff = probing ? HPSilentCutoffProbed : HPSilentCutoff;
+    // Always the conservative window. The shorter probed window was dropping
+    // connected-but-idle devices whenever the ARP probe did not actually draw a
+    // reply on a given device — reporting "no devices" over a device plainly
+    // connected, which is the exact error this whole filter exists to avoid.
+    // Probing still helps when it works (a reply refreshes lastSeen and keeps
+    // the device present); it just no longer shortens the silence that counts
+    // as gone. `probing` is kept in the signature for the CLI's dump.
+    (void)probing;
+    const NSTimeInterval cutoff = HPSilentCutoff;
     NSMutableDictionary *lastExpire = HPBook(books, kHPBookExpire);
     NSMutableDictionary *lastLease  = HPBook(books, kHPBookLease);
     NSMutableDictionary *lastProof  = HPBook(books, kHPBookProof);

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -728,6 +728,13 @@ NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
+NSArray<NSString *> *HPDaemonBlockedMacs(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSArray *macs = file[@"installedBlocks"];
+    return [macs isKindOfClass:[NSArray class]] ? macs : @[];
+}
+
 BOOL HPDaemonIsProbing(void) {
     NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
                               @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -532,6 +532,182 @@ NSArray<NSDictionary *> *HPCopyConnectedDevices(NSArray<NSString *> *hotspotIfNa
     return out;
 }
 
+#pragma mark - Presence
+
+// How long a client may go completely unheard — no captured frame, no ARP
+// refresh, no lease renewal — before it is treated as gone.
+//
+// Minutes rather than seconds, because an idle client really is silent for
+// minutes. Nothing obliges an associated device sitting in a pocket with its
+// screen off to put a frame on the air: between an ARP for the gateway, an mDNS
+// announcement and a DHCP renewal there can be several quiet minutes. A
+// thirty-second window declared those devices departed the moment they went
+// quiet and reinstated them on the next stray packet, so a device that had
+// never gone anywhere flickered between "connected" and "offline" for as long
+// as the pane was open. The cost of the wider window is that a device that
+// really has left lingers for a few minutes; showing a present device as
+// offline is the worse of the two errors.
+const NSTimeInterval HPSilentCutoff = 240.0;
+
+// How stale the daemon's own heartbeat may be before its silence stops meaning
+// anything. It flushes every 10s while its tap is open, whether or not any
+// traffic arrived.
+const NSTimeInterval HPDaemonStaleAfter = 30.0;
+
+// Consecutive evaluations with no evidence before a device already on the list
+// is dropped. One unlucky sample must not be able to move a row.
+const int HPMissesNeeded = 3;
+
+// Every row of the pane asks this question on the same refresh tick. Below this
+// age the previous answer is handed straight back, so the rows cannot disagree
+// with the count above them, and the state machine advances once per tick
+// rather than once per caller.
+static const NSTimeInterval kHPPresenceCoalesce = 1.0;
+
+// Sub-dictionaries of the bookkeeping the filter carries between calls.
+static NSString *const kHPBookExpire = @"expire";   // mac -> last rmx_expire seen
+static NSString *const kHPBookLease  = @"lease";    // mac -> last lease end seen
+static NSString *const kHPBookProof  = @"proof";    // mac -> when last proved present
+static NSString *const kHPBookMisses = @"misses";   // mac -> consecutive silent polls
+
+static NSMutableDictionary *HPBook(NSMutableDictionary *books, NSString *key) {
+    NSMutableDictionary *book = books[key];
+    if (!book) {
+        book = [NSMutableDictionary dictionary];
+        books[key] = book;
+    }
+    return book;
+}
+
+NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
+                                                NSDictionary<NSString *, NSDate *> *lastSeen,
+                                                NSDate *tapSince,
+                                                NSDate *lastFlush,
+                                                NSMutableDictionary *books,
+                                                NSDate *now) {
+    NSMutableDictionary *lastExpire = HPBook(books, kHPBookExpire);
+    NSMutableDictionary *lastLease  = HPBook(books, kHPBookLease);
+    NSMutableDictionary *lastProof  = HPBook(books, kHPBookProof);
+    NSMutableDictionary *misses     = HPBook(books, kHPBookMisses);
+
+    // The daemon's tap is the only thing that can turn silence into a
+    // departure, and only while it is demonstrably capturing.
+    BOOL beating = lastFlush && [now timeIntervalSinceDate:lastFlush] <= HPDaemonStaleAfter;
+
+    // A tap cannot report silence for longer than it has been listening. Right
+    // after the daemon starts, or after the bridge flapped and the tap was
+    // reopened, every stamp is old through no fault of the client — so no
+    // departure may be inferred until the tap has been open for the whole
+    // window it is being asked to interpret.
+    BOOL canProveDeparture = beating && lastSeen.count > 0 && tapSince &&
+        [now timeIntervalSinceDate:tapSince] >= HPSilentCutoff;
+
+    NSMutableArray *present = [NSMutableArray array];
+    NSMutableSet<NSString *> *live = [NSMutableSet set];
+
+    for (NSDictionary *dev in arp) {
+        NSString *mac = dev[HPDevMacKey] ?: @"";
+        [live addObject:mac];
+
+        // Evidence 1: the daemon's tap captured a frame at one end or the other
+        // of this client within the window. It sees sent frames too, so a
+        // client that only receives still counts.
+        NSDate *seen = lastSeen[mac];
+        BOOL heard = seen && [now timeIntervalSinceDate:seen] <= HPSilentCutoff;
+
+        // Evidence 2: the kernel pushed this ARP entry's expiry further out,
+        // which it only does having heard from the neighbour. Compared against
+        // its own previous value and never against the clock — what units
+        // rt_expire is kept in is not worth assuming, whereas "larger than it
+        // was a moment ago" needs no assumption at all.
+        NSNumber *expire = dev[HPDevExpiresKey];
+        NSNumber *wasExpire = lastExpire[mac];
+        BOOL refreshed = expire && wasExpire &&
+            [expire compare:wasExpire] == NSOrderedDescending;
+        if (expire) lastExpire[mac] = expire;
+
+        // Evidence 3: the client renewed its DHCP lease, which it can only do
+        // from here.
+        NSDate *lease = dev[HPDevLeaseEndKey];
+        NSDate *wasLease = lastLease[mac];
+        BOOL renewed = lease && wasLease &&
+            [lease compare:wasLease] == NSOrderedDescending;
+        if (lease) lastLease[mac] = lease;
+
+        if (heard || refreshed || renewed) {
+            lastProof[mac] = now;
+            misses[mac] = @0;
+            [present addObject:dev];
+            continue;
+        }
+
+        // Nothing heard this round. With no daemon data, or a tap that has not
+        // been listening long enough, that means nothing: absence of evidence
+        // is not evidence of departure.
+        if (!canProveDeparture) {
+            [present addObject:dev];
+            continue;
+        }
+
+        // A device has to fail repeatedly AND have been unheard for the whole
+        // window before it is dropped — the same hysteresis the hotspot status
+        // row uses, for the same reason. A MAC with no proof on record has only
+        // just been polled for the first time; the tap's own stamps, which
+        // survive across daemon restarts, decide that one.
+        int m = [misses[mac] intValue] + 1;
+        misses[mac] = @(m);
+        NSDate *proof = lastProof[mac];
+        NSTimeInterval quiet = proof ? [now timeIntervalSinceDate:proof]
+                                     : HPSilentCutoff;
+        if (m >= HPMissesNeeded && quiet >= HPSilentCutoff) continue;
+        [present addObject:dev];
+    }
+
+    // Forget the bookkeeping for MACs the ARP table no longer carries, or these
+    // four dictionaries would grow for the life of the process. A client with a
+    // randomised MAC mints a new one on every reconnect.
+    for (NSMutableDictionary *book in @[lastExpire, lastLease, lastProof, misses]) {
+        for (NSString *mac in [book.allKeys copy]) {
+            if (![live containsObject:mac]) [book removeObjectForKey:mac];
+        }
+    }
+    return present;
+}
+
+NSArray<NSDictionary *> *HPCopyPresentDevices(NSArray<NSString *> *hotspotIfNames) {
+    static NSObject *lock;
+    static NSMutableDictionary *books;
+    static NSArray<NSDictionary *> *cached;
+    static NSDate *cachedAt;
+    static NSString *cachedKey;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        lock  = [NSObject new];
+        books = [NSMutableDictionary dictionary];
+    });
+
+    @synchronized (lock) {
+        NSDate *now = [NSDate date];
+        NSString *key = [hotspotIfNames componentsJoinedByString:@","] ?: @"";
+        if (cached && cachedAt && [cachedKey isEqualToString:key] &&
+            [now timeIntervalSinceDate:cachedAt] < kHPPresenceCoalesce) {
+            return cached;
+        }
+
+        NSArray *present =
+            HPFilterPresentDevices(HPCopyConnectedDevices(hotspotIfNames) ?: @[],
+                                   HPCopyDaemonLastSeen(),
+                                   HPDaemonTapSince(),
+                                   HPDaemonLastFlush(),
+                                   books,
+                                   now);
+        cached    = [present copy];
+        cachedAt  = now;
+        cachedKey = key;
+        return cached;
+    }
+}
+
 #pragma mark - Per-device bytes (from the daemon)
 
 NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
@@ -539,6 +715,13 @@ NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
                               @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
     NSDictionary *bytes = file[@"bytesByMac"];
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
+}
+
+NSDate *HPDaemonTapSince(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDate *since = file[@"tapSince"];
+    return [since isKindOfClass:[NSDate class]] ? since : nil;
 }
 
 NSDate *HPDaemonLastFlush(void) {

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -24,6 +24,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <ifaddrs.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
@@ -79,6 +80,10 @@ static NSMutableSet<NSString *> *gTouchedMacs;
 // after a bridge flap every per-client timestamp is stale at once, and a reader
 // that could not see the difference declared connected devices departed.
 static NSDate *gTapSince;
+// Whether the tap could be opened for writing, and so whether the presence
+// probes below are actually going out. Published, because a reader that assumed
+// probing while it was not happening would rule live devices absent.
+static BOOL gCanProbe;
 static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
 
 // A client with a randomised MAC mints a new entry every time it reconnects, so
@@ -148,6 +153,7 @@ static void HPFlushCounters(void) {
         // Absent rather than null while there is no tap, so a reader that finds
         // it knows a tap was open at the moment this was written.
         if (gTapSince) payload[@"tapSince"] = gTapSince;
+        payload[@"probing"] = @(gTapSince != nil && gCanProbe);
         NSData *data = [NSPropertyListSerialization dataWithPropertyList:payload
                                                                   format:NSPropertyListXMLFormat_v1_0
                                                                  options:0
@@ -314,12 +320,28 @@ static NSDictionary *HPFindBridge(void) {
 
 /// Open a free /dev/bpfN bound to `ifname`. Returns -1 on failure.
 static int HPOpenBPF(NSString *ifname) {
+    // Read/write, because the tap is also what the presence probes go out
+    // through: writing a frame to a BPF device puts it on the interface, which
+    // saves opening a second socket to reach clients that are already on the
+    // other side of this very bridge. A node that will only open read-only
+    // still counts bytes perfectly well; it just cannot ask anyone anything.
     int fd = -1;
+    gCanProbe = NO;
     for (int i = 0; i < 32; i++) {
         char path[32];
         snprintf(path, sizeof(path), "/dev/bpf%d", i);
+        fd = open(path, O_RDWR);
+        if (fd >= 0) {
+            gCanProbe = YES;
+            break;
+        }
+        if (errno == EBUSY) continue;   // in use by something else; try the next
         fd = open(path, O_RDONLY);
-        if (fd >= 0) break;
+        if (fd >= 0) {
+            HPDaemonLog(@"%s opened read-only (%s) — presence probes disabled",
+                        path, strerror(errno));
+            break;
+        }
         if (errno != EBUSY && errno != EPERM && errno != EACCES) {
             // ENOENT means we ran past the last node; anything else is worth a look.
             if (errno != ENOENT) HPDaemonLog(@"open %s: %s", path, strerror(errno));
@@ -355,6 +377,13 @@ static int HPOpenBPF(NSString *ifname) {
     u_int on = 1;
     ioctl(fd, HP_BIOCSSEESENT, &on);
 
+    // Probes are written with their Ethernet header already filled in, so the
+    // kernel must be told not to supply a source address of its own.
+    if (gCanProbe && ioctl(fd, HP_BIOCSHDRCMPLT, &on) < 0) {
+        HPDaemonLog(@"BIOCSHDRCMPLT: %s — presence probes disabled", strerror(errno));
+        gCanProbe = NO;
+    }
+
     // Capture just the Ethernet header: this is what keeps the tap cheap, while
     // bh_datalen still reports each frame's true length.
     static struct hp_bpf_insn insns[] = {
@@ -375,6 +404,132 @@ static int HPOpenBPF(NSString *ifname) {
     return fd;
 }
 
+#pragma mark - Presence probes
+
+// How often each client is asked whether it is still there. Every probe is one
+// 42-byte frame, and a client that is present answers within milliseconds.
+static const NSTimeInterval kProbeInterval = 10.0;
+
+/// An ARP request, laid out as it goes on the wire.
+struct hp_arp_probe {
+    unsigned char dstMac[6];
+    unsigned char srcMac[6];
+    unsigned char etherType[2];   // 0x0806
+    unsigned char hwType[2];      // 0x0001, Ethernet
+    unsigned char protoType[2];   // 0x0800, IPv4
+    unsigned char hwLen;          // 6
+    unsigned char protoLen;       // 4
+    unsigned char op[2];          // 0x0001, request
+    unsigned char senderMac[6];
+    unsigned char senderIp[4];
+    unsigned char targetMac[6];
+    unsigned char targetIp[4];
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct hp_arp_probe) == 42, "ARP request is 42 bytes on Ethernet");
+
+/// The bridge's own IPv4 address, which every probe claims to come from.
+///
+/// getifaddrs() rather than a sysctl walk: this wants an address, not a
+/// counter, and it is the 32-bit byte counters that made getifaddrs unusable
+/// elsewhere. Zero when the bridge has no address yet, which means no probe can
+/// be sent — a request from 0.0.0.0 is an address-probe with different
+/// semantics, and clients are entitled to ignore it.
+static uint32_t HPBridgeAddress(NSString *ifname) {
+    struct ifaddrs *list = NULL;
+    if (getifaddrs(&list) != 0) return 0;
+    uint32_t addr = 0;
+    for (struct ifaddrs *a = list; a; a = a->ifa_next) {
+        if (!a->ifa_addr || a->ifa_addr->sa_family != AF_INET) continue;
+        if (!a->ifa_name || ![ifname isEqualToString:@(a->ifa_name)]) continue;
+        addr = ((struct sockaddr_in *)a->ifa_addr)->sin_addr.s_addr;
+        break;
+    }
+    freeifaddrs(list);
+    return addr;
+}
+
+/// Parse "1e:07:67:bb:5b:3f" into six bytes. NO unless it is exactly that.
+static BOOL HPParseMac(NSString *mac, unsigned char out[6]) {
+    NSArray<NSString *> *parts = [mac componentsSeparatedByString:@":"];
+    if (parts.count != 6) return NO;
+    for (int i = 0; i < 6; i++) {
+        unsigned int byte = 0;
+        NSScanner *sc = [NSScanner scannerWithString:parts[i]];
+        if (![sc scanHexInt:&byte] || !sc.isAtEnd || byte > 0xff) return NO;
+        out[i] = (unsigned char)byte;
+    }
+    return YES;
+}
+
+/// Ask every client whether it is still there.
+///
+/// The ARP table cannot answer that: it only ever records that a client *was*
+/// here, and a departed entry sits there counting down for the rest of its
+/// lifetime. Waiting to overhear a client instead cannot answer it either,
+/// because a device that is connected and idle is entitled to say nothing for
+/// minutes on end — which is exactly what made connected devices get reported
+/// as offline. A request has an answer: a client that is still associated
+/// replies in milliseconds, the tap sees the reply, and its timestamp moves.
+/// Silence after several unanswered requests is then worth something.
+///
+/// One unicast request per client, which is what neighbour-unreachability
+/// detection does everywhere else; nothing is broadcast and nothing else on the
+/// network is disturbed.
+static void HPProbeClients(int fd, NSString *bridgeName, NSString *bridgeMac) {
+    if (!gCanProbe || fd < 0) return;
+
+    unsigned char srcMac[6];
+    if (!HPParseMac(bridgeMac ?: @"", srcMac)) return;
+    uint32_t senderIp = HPBridgeAddress(bridgeName);
+    if (senderIp == 0) return;
+
+    NSArray<NSString *> *names = HPHotspotInterfaceNames(HPCopyInterfaces());
+    NSArray<NSDictionary *> *clients = HPCopyConnectedDevices(names);
+    static BOOL warned = NO;
+
+    for (NSDictionary *client in clients) {
+        // No need to ask a client that has already spoken since the last flush:
+        // it has answered the question by talking. Probes therefore go only to
+        // the devices whose presence is actually in doubt, which on a busy
+        // hotspot is none of them.
+        if ([gTouchedMacs containsObject:client[HPDevMacKey] ?: @""]) continue;
+
+        unsigned char dstMac[6];
+        if (!HPParseMac(client[HPDevMacKey] ?: @"", dstMac)) continue;
+        struct in_addr target;
+        if (inet_pton(AF_INET, [(client[HPDevIPKey] ?: @"") UTF8String], &target) != 1) continue;
+
+        struct hp_arp_probe p;
+        memset(&p, 0, sizeof(p));
+        memcpy(p.dstMac, dstMac, 6);
+        memcpy(p.srcMac, srcMac, 6);
+        p.etherType[0] = 0x08; p.etherType[1] = 0x06;
+        p.hwType[1]    = 0x01;
+        p.protoType[0] = 0x08;
+        p.hwLen        = 6;
+        p.protoLen     = 4;
+        p.op[1]        = 0x01;
+        memcpy(p.senderMac, srcMac, 6);
+        memcpy(p.senderIp, &senderIp, 4);
+        memcpy(p.targetMac, dstMac, 6);
+        memcpy(p.targetIp, &target.s_addr, 4);
+
+        if (write(fd, &p, sizeof(p)) < 0) {
+            // One report, then stop: if the kernel will not take a frame from
+            // us it will not take the next one either, and the passive rule is
+            // a working fallback. Readers are told, so they widen their window.
+            if (!warned) {
+                HPDaemonLog(@"probe write: %s — falling back to passive presence",
+                            strerror(errno));
+                warned = YES;
+            }
+            gCanProbe = NO;
+            return;
+        }
+    }
+}
+
 static void HPConsume(const char *buf, ssize_t len, NSString *bridgeMac) {
     const char *p = buf;
     const char *end = buf + len;
@@ -390,15 +545,29 @@ static void HPConsume(const char *buf, ssize_t len, NSString *bridgeMac) {
 
             // Whichever end is not the bridge itself is the client. Broadcast
             // and multicast are not devices.
-            NSString *client = [src isEqualToString:bridgeMac] ? dst : src;
+            BOOL fromClient = ![src isEqualToString:bridgeMac];
+            NSString *client = fromClient ? src : dst;
             unsigned int firstOctet = 0;
             sscanf([[client substringToIndex:2] UTF8String], "%x", &firstOctet);
             BOOL isGroupAddress = (firstOctet & 0x01) != 0;
+            // The snap length is 14, so the ethertype is always in hand.
+            BOOL isArp = bh->bh_caplen >= 14 && (const char *)frame + 14 <= end &&
+                         frame[12] == 0x08 && frame[13] == 0x06;
 
             if (!isGroupAddress && ![client isEqualToString:bridgeMac]) {
-                uint64_t prev = [gBytesByMac[client] unsignedLongLongValue];
-                gBytesByMac[client] = @(prev + bh->bh_datalen);
-                [gTouchedMacs addObject:client];
+                // An ARP frame the phone sent is one of the presence probes
+                // above: this daemon's own overhead, not the client's traffic.
+                // Counting those would trickle our bytes onto every device's
+                // total for as long as the hotspot was up.
+                if (fromClient || !isArp) {
+                    uint64_t prev = [gBytesByMac[client] unsignedLongLongValue];
+                    gBytesByMac[client] = @(prev + bh->bh_datalen);
+                }
+                // Bytes are counted in both directions; presence is not. Only a
+                // frame the client SENT is evidence that it is here — a frame
+                // the phone sent toward it proves nothing, least of all a probe,
+                // which would otherwise answer its own question.
+                if (fromClient) [gTouchedMacs addObject:client];
             }
         }
 
@@ -467,6 +636,7 @@ int main(int argc, char *argv[]) {
         NSString *bridgeName = nil;
         NSString *bridgeMac = nil;
         NSDate *lastFlush = [NSDate date];
+        NSDate *lastProbe = [NSDate distantPast];
 
         while (1) {
             @autoreleasepool {
@@ -518,6 +688,10 @@ int main(int argc, char *argv[]) {
                         continue;
                     }
                     gTapSince = [NSDate date];
+                    // Ask straight away rather than waiting out the first
+                    // interval: a client that attached before the tap opened
+                    // has no timestamp at all until something is heard from it.
+                    lastProbe = [NSDate distantPast];
                 }
 
                 if (fd < 0) {
@@ -577,6 +751,13 @@ int main(int argc, char *argv[]) {
                         gTapSince = nil;
                         HPFlushCounters();
                     }
+                }
+
+                // Probe before flushing, so a reply that arrives in the same
+                // breath is stamped by this flush rather than the next one.
+                if ([[NSDate date] timeIntervalSinceDate:lastProbe] >= kProbeInterval) {
+                    HPProbeClients(fd, bridgeName, bridgeMac);
+                    lastProbe = [NSDate date];
                 }
 
                 if ([[NSDate date] timeIntervalSinceDate:lastFlush] >= kFlushInterval) {

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -86,6 +86,15 @@ static NSDate *gTapSince;
 static BOOL gCanProbe;
 static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
 
+// A one-line breadcrumb saying what this process is doing, so the UI and CLI
+// can explain why per-device figures or blocking are absent instead of only
+// showing "helper not running". Written on startup and at each state change —
+// never in a tight loop — so it cannot become the 8,600-writes-a-day problem
+// the state file once was. Its absence means the binary never ran at all, which
+// is itself the answer (a LaunchDaemon that never bootstrapped, or a signature
+// the device refused to exec).
+static NSString *gStatusPath = @"/var/mobile/Library/Caches/hotspotpro-daemon.plist";
+
 // A client with a randomised MAC mints a new entry every time it reconnects, so
 // without a bound this file would grow for the life of the install.
 static const NSTimeInterval kMaxDeviceAge = 60 * 60 * 24 * 45;   // 45 days
@@ -98,6 +107,27 @@ static void HPDaemonLog(NSString *format, ...) {
     NSString *msg = [[NSString alloc] initWithFormat:format arguments:args];
     va_end(args);
     HPLog(@"[daemon] %@", msg);
+}
+
+/// Record what the daemon is doing right now. No-op when the state has not
+/// changed since the last call, so it is safe to call from inside the loop.
+static void HPWriteDaemonStatus(NSString *state) {
+    static NSString *last;
+    if ([state isEqualToString:last]) return;
+    last = state;
+    @try {
+        NSDictionary *payload = @{
+            @"state"    : state,
+            @"pid"      : @(getpid()),
+            @"firmware" : [[NSProcessInfo processInfo] operatingSystemVersionString] ?: @"?",
+            @"updated"  : [NSDate date],
+        };
+        [payload writeToFile:gStatusPath atomically:YES];
+        [[NSFileManager defaultManager] setAttributes:@{ NSFilePosixPermissions : @0644 }
+                                         ofItemAtPath:gStatusPath error:NULL];
+    } @catch (NSException *e) {
+        HPDaemonLog(@"status write failed: %@", e);
+    }
 }
 
 /// Forget devices that stopped appearing long ago, and cap the total.
@@ -599,8 +629,10 @@ int main(int argc, char *argv[]) {
         NSOperatingSystemVersion ios18 = { 18, 0, 0 };
         if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:ios18]) {
             HPDaemonLog(@"iOS 18+ — untested firmware, exiting without tapping");
+            HPWriteDaemonStatus(@"gated-ios18");
             return 0;
         }
+        HPWriteDaemonStatus(@"starting");
 
         HPClearStaleBlocks();
 
@@ -650,6 +682,7 @@ int main(int argc, char *argv[]) {
                 // is captured and nothing is counted, and idle cheaply until it
                 // is switched back on.
                 if (![HPConfig()[HPCfgEnabledKey] boolValue]) {
+                    HPWriteDaemonStatus(@"tracking-off");
                     if (fd >= 0) {
                         HPDaemonLog(@"tracking disabled, closing tap");
                         close(fd);
@@ -690,10 +723,12 @@ int main(int argc, char *argv[]) {
                     fd = HPOpenBPF(bridgeName);
                     if (fd < 0) {
                         // Do not spin retrying a tap that cannot be opened.
+                        HPWriteDaemonStatus(@"no-bpf");
                         sleep(30);
                         continue;
                     }
                     gTapSince = [NSDate date];
+                    HPWriteDaemonStatus(gCanProbe ? @"running" : @"running-noprobe");
                     // Ask straight away rather than waiting out the first
                     // interval: a client that attached before the tap opened
                     // has no timestamp at all until something is heard from it.
@@ -701,6 +736,7 @@ int main(int argc, char *argv[]) {
                 }
 
                 if (fd < 0) {
+                    HPWriteDaemonStatus(@"hotspot-off");
                     // Hotspot off. Rather than waking on a timer to ask whether
                     // anything changed, block until the kernel says so: the
                     // routing socket becomes readable the moment an interface

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -154,6 +154,12 @@ static void HPFlushCounters(void) {
         // it knows a tap was open at the moment this was written.
         if (gTapSince) payload[@"tapSince"] = gTapSince;
         payload[@"probing"] = @(gTapSince != nil && gCanProbe);
+        // The MACs a reject route is actually installed for right now, so the
+        // UI can tell "the tracker wants this blocked" from "the block is
+        // really in place". They diverge when this daemon is not running or
+        // cannot write routes on this firmware, which is exactly the case that
+        // showed "Blocked" over a device that still had working internet.
+        payload[@"installedBlocks"] = [gInstalledBlocks allKeys];
         NSData *data = [NSPropertyListSerialization dataWithPropertyList:payload
                                                                   format:NSPropertyListXMLFormat_v1_0
                                                                  options:0

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -269,8 +269,27 @@ static BOOL HPSetRouteBlock(NSString *ip, BOOL blocked) {
                     strerror(failure));
         return NO;
     }
-    HPDaemonLog(@"%@ %@", blocked ? @"blocked" : @"unblocked", ip);
+    // Announce only a real change (failure 0). EEXIST/ESRCH mean nothing moved,
+    // so the whole-subnet sweep below can call this for every client address
+    // without filling the log with "unblocked" lines for routes that were never
+    // there.
+    if (failure == 0) HPDaemonLog(@"%@ %@", blocked ? @"blocked" : @"unblocked", ip);
     return YES;
+}
+
+/// Delete any reject route sitting on a hotspot client address, tracked or not.
+///
+/// iOS hands clients 172.20.10.2 .. .14 (a /28, .1 is the phone, .15 broadcast),
+/// so sweeping that whole range clears a block no matter how it got there.
+/// This is the backstop that makes a block impossible to strand: a daemon
+/// killed between installing a route and recording it leaves an orphan that
+/// gInstalledBlocks and the installed-plist never knew about, which used to
+/// survive until a reboot. Deleting a route that is not there is a harmless
+/// ESRCH, so this is safe to run unconditionally.
+static void HPSweepHotspotRejectRoutes(void) {
+    for (int host = 2; host <= 14; host++) {
+        HPSetRouteBlock([NSString stringWithFormat:@"172.20.10.%d", host], NO);
+    }
 }
 
 static void HPSaveInstalledBlocks(void) {
@@ -487,6 +506,10 @@ int main(int argc, char *argv[]) {
         HPWriteDaemonStatus(@"starting");
 
         HPClearStaleBlocks();
+        // And sweep the whole client range, so an orphan route no tracking file
+        // remembers — left by a daemon that was killed mid-block — is gone by
+        // the next start rather than surviving until a reboot.
+        HPSweepHotspotRejectRoutes();
 
         // Counters survive a hotspot session; they are cumulative since the
         // daemon started, and the tweak turns them into per-period figures by
@@ -542,15 +565,16 @@ int main(int argc, char *argv[]) {
                         gTapSince = nil;
                         HPFlushCounters();
                     }
-                    // Tracking off must not leave anyone cut off.
+                    // Tracking off must not leave anyone cut off. Clear what we
+                    // tracked, then sweep the whole client range so an orphan
+                    // route we no longer remember cannot strand a device —
+                    // which is exactly what made a blocked device stay cut off
+                    // even after tracking was switched off.
                     if (gInstalledBlocks.count) {
-                        for (NSString *mac in [gInstalledBlocks.allKeys copy]) {
-                            if (HPSetRouteBlock(gInstalledBlocks[mac], NO)) {
-                                [gInstalledBlocks removeObjectForKey:mac];
-                            }
-                        }
+                        [gInstalledBlocks removeAllObjects];
                         HPSaveInstalledBlocks();
                     }
+                    HPSweepHotspotRejectRoutes();
                     sleep(15);
                     continue;
                 }

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -78,9 +78,6 @@ static NSMutableSet<NSString *> *gTouchedMacs;
 // after a bridge flap every per-client timestamp is stale at once, and a reader
 // that could not see the difference declared connected devices departed.
 static NSDate *gTapSince;
-// Whether the tap could be opened for writing, and so whether the presence
-// probes below are actually going out. Published, because a reader that assumed
-// probing while it was not happening would rule live devices absent.
 static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
 
 // A one-line breadcrumb saying what this process is doing, so the UI and CLI

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -74,6 +74,11 @@ static const NSTimeInterval kFlushInterval = 10.0;
 static NSMutableDictionary<NSString *, NSNumber *> *gBytesByMac;
 static NSMutableDictionary<NSString *, NSDate *> *gLastSeenByMac;
 static NSMutableSet<NSString *> *gTouchedMacs;
+// When the tap now open was opened, or nil while there is none. Published so
+// readers can tell "this client has been silent" from "nobody was listening":
+// after a bridge flap every per-client timestamp is stale at once, and a reader
+// that could not see the difference declared connected devices departed.
+static NSDate *gTapSince;
 static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
 
 // A client with a randomised MAC mints a new entry every time it reconnects, so
@@ -126,7 +131,6 @@ static void HPPruneDevices(void) {
 
 /// Counters are written where the tweak (running as mobile) can read them.
 static void HPFlushCounters(void) {
-    if (!gBytesByMac.count) return;
     @try {
         // Stamp only the devices that actually moved data since the last flush,
         // so timestamps cost nothing per packet.
@@ -136,11 +140,14 @@ static void HPFlushCounters(void) {
         HPPruneDevices();
 
         NSString *tmp = [gDevicesPath stringByAppendingPathExtension:@"tmp"];
-        NSDictionary *payload = @{
+        NSMutableDictionary *payload = [@{
             @"bytesByMac"   : gBytesByMac,
             @"lastSeenByMac": gLastSeenByMac,
             @"updated"      : [NSDate date],
-        };
+        } mutableCopy];
+        // Absent rather than null while there is no tap, so a reader that finds
+        // it knows a tap was open at the moment this was written.
+        if (gTapSince) payload[@"tapSince"] = gTapSince;
         NSData *data = [NSPropertyListSerialization dataWithPropertyList:payload
                                                                   format:NSPropertyListXMLFormat_v1_0
                                                                  options:0
@@ -472,6 +479,7 @@ int main(int argc, char *argv[]) {
                         close(fd);
                         fd = -1;
                         bridgeName = nil;
+                        gTapSince = nil;
                         HPFlushCounters();
                     }
                     // Tracking off must not leave anyone cut off.
@@ -496,6 +504,7 @@ int main(int argc, char *argv[]) {
                     close(fd);
                     fd = -1;
                     bridgeName = nil;
+                    gTapSince = nil;
                     HPFlushCounters();
                 }
 
@@ -508,6 +517,7 @@ int main(int argc, char *argv[]) {
                         sleep(30);
                         continue;
                     }
+                    gTapSince = [NSDate date];
                 }
 
                 if (fd < 0) {
@@ -564,6 +574,7 @@ int main(int argc, char *argv[]) {
                         if (errno != ENXIO) HPDaemonLog(@"read: %s", strerror(errno));
                         close(fd);
                         fd = -1;
+                        gTapSince = nil;
                         HPFlushCounters();
                     }
                 }

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -24,7 +24,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
-#include <ifaddrs.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
@@ -37,7 +36,6 @@
 #define HP_BIOCGDLT      _IOR ('B', 106, u_int)
 #define HP_BIOCSETIF     _IOW ('B', 108, struct ifreq)
 #define HP_BIOCIMMEDIATE _IOW ('B', 112, u_int)
-#define HP_BIOCSHDRCMPLT _IOW ('B', 117, u_int)
 #define HP_BIOCSSEESENT  _IOW ('B', 118, u_int)
 
 #define HP_DLT_EN10MB 1
@@ -83,7 +81,6 @@ static NSDate *gTapSince;
 // Whether the tap could be opened for writing, and so whether the presence
 // probes below are actually going out. Published, because a reader that assumed
 // probing while it was not happening would rule live devices absent.
-static BOOL gCanProbe;
 static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
 
 // A one-line breadcrumb saying what this process is doing, so the UI and CLI
@@ -188,7 +185,6 @@ static void HPFlushCounters(void) {
         // Absent rather than null while there is no tap, so a reader that finds
         // it knows a tap was open at the moment this was written.
         if (gTapSince) payload[@"tapSince"] = gTapSince;
-        payload[@"probing"] = @(gTapSince != nil && gCanProbe);
         // The MACs a reject route is actually installed for right now, so the
         // UI can tell "the tracker wants this blocked" from "the block is
         // really in place". They diverge when this daemon is not running or
@@ -359,28 +355,14 @@ static NSDictionary *HPFindBridge(void) {
 
 /// Open a free /dev/bpfN bound to `ifname`. Returns -1 on failure.
 static int HPOpenBPF(NSString *ifname) {
-    // Read/write, because the tap is also what the presence probes go out
-    // through: writing a frame to a BPF device puts it on the interface, which
-    // saves opening a second socket to reach clients that are already on the
-    // other side of this very bridge. A node that will only open read-only
-    // still counts bytes perfectly well; it just cannot ask anyone anything.
+    // Read-only: this tap only ever reads frames to count them. It does not
+    // write anything to the interface.
     int fd = -1;
-    gCanProbe = NO;
     for (int i = 0; i < 32; i++) {
         char path[32];
         snprintf(path, sizeof(path), "/dev/bpf%d", i);
-        fd = open(path, O_RDWR);
-        if (fd >= 0) {
-            gCanProbe = YES;
-            break;
-        }
-        if (errno == EBUSY) continue;   // in use by something else; try the next
         fd = open(path, O_RDONLY);
-        if (fd >= 0) {
-            HPDaemonLog(@"%s opened read-only (%s) — presence probes disabled",
-                        path, strerror(errno));
-            break;
-        }
+        if (fd >= 0) break;
         if (errno != EBUSY && errno != EPERM && errno != EACCES) {
             // ENOENT means we ran past the last node; anything else is worth a look.
             if (errno != ENOENT) HPDaemonLog(@"open %s: %s", path, strerror(errno));
@@ -416,13 +398,6 @@ static int HPOpenBPF(NSString *ifname) {
     u_int on = 1;
     ioctl(fd, HP_BIOCSSEESENT, &on);
 
-    // Probes are written with their Ethernet header already filled in, so the
-    // kernel must be told not to supply a source address of its own.
-    if (gCanProbe && ioctl(fd, HP_BIOCSHDRCMPLT, &on) < 0) {
-        HPDaemonLog(@"BIOCSHDRCMPLT: %s — presence probes disabled", strerror(errno));
-        gCanProbe = NO;
-    }
-
     // Capture just the Ethernet header: this is what keeps the tap cheap, while
     // bh_datalen still reports each frame's true length.
     static struct hp_bpf_insn insns[] = {
@@ -441,132 +416,6 @@ static int HPOpenBPF(NSString *ifname) {
 
     HPDaemonLog(@"tapping %@ (fd %d, buffer %u bytes)", ifname, fd, blen);
     return fd;
-}
-
-#pragma mark - Presence probes
-
-// How often each client is asked whether it is still there. Every probe is one
-// 42-byte frame, and a client that is present answers within milliseconds.
-static const NSTimeInterval kProbeInterval = 10.0;
-
-/// An ARP request, laid out as it goes on the wire.
-struct hp_arp_probe {
-    unsigned char dstMac[6];
-    unsigned char srcMac[6];
-    unsigned char etherType[2];   // 0x0806
-    unsigned char hwType[2];      // 0x0001, Ethernet
-    unsigned char protoType[2];   // 0x0800, IPv4
-    unsigned char hwLen;          // 6
-    unsigned char protoLen;       // 4
-    unsigned char op[2];          // 0x0001, request
-    unsigned char senderMac[6];
-    unsigned char senderIp[4];
-    unsigned char targetMac[6];
-    unsigned char targetIp[4];
-} __attribute__((packed));
-
-_Static_assert(sizeof(struct hp_arp_probe) == 42, "ARP request is 42 bytes on Ethernet");
-
-/// The bridge's own IPv4 address, which every probe claims to come from.
-///
-/// getifaddrs() rather than a sysctl walk: this wants an address, not a
-/// counter, and it is the 32-bit byte counters that made getifaddrs unusable
-/// elsewhere. Zero when the bridge has no address yet, which means no probe can
-/// be sent — a request from 0.0.0.0 is an address-probe with different
-/// semantics, and clients are entitled to ignore it.
-static uint32_t HPBridgeAddress(NSString *ifname) {
-    struct ifaddrs *list = NULL;
-    if (getifaddrs(&list) != 0) return 0;
-    uint32_t addr = 0;
-    for (struct ifaddrs *a = list; a; a = a->ifa_next) {
-        if (!a->ifa_addr || a->ifa_addr->sa_family != AF_INET) continue;
-        if (!a->ifa_name || ![ifname isEqualToString:@(a->ifa_name)]) continue;
-        addr = ((struct sockaddr_in *)a->ifa_addr)->sin_addr.s_addr;
-        break;
-    }
-    freeifaddrs(list);
-    return addr;
-}
-
-/// Parse "1e:07:67:bb:5b:3f" into six bytes. NO unless it is exactly that.
-static BOOL HPParseMac(NSString *mac, unsigned char out[6]) {
-    NSArray<NSString *> *parts = [mac componentsSeparatedByString:@":"];
-    if (parts.count != 6) return NO;
-    for (int i = 0; i < 6; i++) {
-        unsigned int byte = 0;
-        NSScanner *sc = [NSScanner scannerWithString:parts[i]];
-        if (![sc scanHexInt:&byte] || !sc.isAtEnd || byte > 0xff) return NO;
-        out[i] = (unsigned char)byte;
-    }
-    return YES;
-}
-
-/// Ask every client whether it is still there.
-///
-/// The ARP table cannot answer that: it only ever records that a client *was*
-/// here, and a departed entry sits there counting down for the rest of its
-/// lifetime. Waiting to overhear a client instead cannot answer it either,
-/// because a device that is connected and idle is entitled to say nothing for
-/// minutes on end — which is exactly what made connected devices get reported
-/// as offline. A request has an answer: a client that is still associated
-/// replies in milliseconds, the tap sees the reply, and its timestamp moves.
-/// Silence after several unanswered requests is then worth something.
-///
-/// One unicast request per client, which is what neighbour-unreachability
-/// detection does everywhere else; nothing is broadcast and nothing else on the
-/// network is disturbed.
-static void HPProbeClients(int fd, NSString *bridgeName, NSString *bridgeMac) {
-    if (!gCanProbe || fd < 0) return;
-
-    unsigned char srcMac[6];
-    if (!HPParseMac(bridgeMac ?: @"", srcMac)) return;
-    uint32_t senderIp = HPBridgeAddress(bridgeName);
-    if (senderIp == 0) return;
-
-    NSArray<NSString *> *names = HPHotspotInterfaceNames(HPCopyInterfaces());
-    NSArray<NSDictionary *> *clients = HPCopyConnectedDevices(names);
-    static BOOL warned = NO;
-
-    for (NSDictionary *client in clients) {
-        // No need to ask a client that has already spoken since the last flush:
-        // it has answered the question by talking. Probes therefore go only to
-        // the devices whose presence is actually in doubt, which on a busy
-        // hotspot is none of them.
-        if ([gTouchedMacs containsObject:client[HPDevMacKey] ?: @""]) continue;
-
-        unsigned char dstMac[6];
-        if (!HPParseMac(client[HPDevMacKey] ?: @"", dstMac)) continue;
-        struct in_addr target;
-        if (inet_pton(AF_INET, [(client[HPDevIPKey] ?: @"") UTF8String], &target) != 1) continue;
-
-        struct hp_arp_probe p;
-        memset(&p, 0, sizeof(p));
-        memcpy(p.dstMac, dstMac, 6);
-        memcpy(p.srcMac, srcMac, 6);
-        p.etherType[0] = 0x08; p.etherType[1] = 0x06;
-        p.hwType[1]    = 0x01;
-        p.protoType[0] = 0x08;
-        p.hwLen        = 6;
-        p.protoLen     = 4;
-        p.op[1]        = 0x01;
-        memcpy(p.senderMac, srcMac, 6);
-        memcpy(p.senderIp, &senderIp, 4);
-        memcpy(p.targetMac, dstMac, 6);
-        memcpy(p.targetIp, &target.s_addr, 4);
-
-        if (write(fd, &p, sizeof(p)) < 0) {
-            // One report, then stop: if the kernel will not take a frame from
-            // us it will not take the next one either, and the passive rule is
-            // a working fallback. Readers are told, so they widen their window.
-            if (!warned) {
-                HPDaemonLog(@"probe write: %s — falling back to passive presence",
-                            strerror(errno));
-                warned = YES;
-            }
-            gCanProbe = NO;
-            return;
-        }
-    }
 }
 
 static void HPConsume(const char *buf, ssize_t len, NSString *bridgeMac) {
@@ -677,7 +526,6 @@ int main(int argc, char *argv[]) {
         NSString *bridgeName = nil;
         NSString *bridgeMac = nil;
         NSDate *lastFlush = [NSDate date];
-        NSDate *lastProbe = [NSDate distantPast];
 
         while (1) {
             @autoreleasepool {
@@ -731,11 +579,7 @@ int main(int argc, char *argv[]) {
                         continue;
                     }
                     gTapSince = [NSDate date];
-                    HPWriteDaemonStatus(gCanProbe ? @"running" : @"running-noprobe");
-                    // Ask straight away rather than waiting out the first
-                    // interval: a client that attached before the tap opened
-                    // has no timestamp at all until something is heard from it.
-                    lastProbe = [NSDate distantPast];
+                    HPWriteDaemonStatus(@"running");
                 }
 
                 if (fd < 0) {
@@ -796,13 +640,6 @@ int main(int argc, char *argv[]) {
                         gTapSince = nil;
                         HPFlushCounters();
                     }
-                }
-
-                // Probe before flushing, so a reply that arrives in the same
-                // breath is stamped by this flush rather than the next one.
-                if ([[NSDate date] timeIntervalSinceDate:lastProbe] >= kProbeInterval) {
-                    HPProbeClients(fd, bridgeName, bridgeMac);
-                    lastProbe = [NSDate date];
                 }
 
                 if ([[NSDate date] timeIntervalSinceDate:lastFlush] >= kFlushInterval) {

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -95,6 +95,11 @@ static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.
 // the device refused to exec).
 static NSString *gStatusPath = @"/var/mobile/Library/Caches/hotspotpro-daemon.plist";
 
+// MAC -> IP for every block this daemon has installed. Declared here, up with
+// the other state, because the flush publishes its keys — it is read well
+// before the blocking section that maintains it is reached in the file.
+static NSMutableDictionary<NSString *, NSString *> *gInstalledBlocks;
+
 // A client with a randomised MAC mints a new entry every time it reconnects, so
 // without a bound this file would grow for the life of the install.
 static const NSTimeInterval kMaxDeviceAge = 60 * 60 * 24 * 45;   // 45 days
@@ -211,8 +216,6 @@ static void HPFlushCounters(void) {
 
 #pragma mark - Blocking
 
-// MAC -> IP for every block this daemon has installed.
-static NSMutableDictionary<NSString *, NSString *> *gInstalledBlocks;
 static NSString *gInstalledPath = @"/var/mobile/Library/Caches/hotspotpro-installed.plist";
 
 /// Install or remove a reject route for one hotspot client.

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -320,6 +320,25 @@ static void HPApplyBlocklist(void) {
         }
 
         HPSaveInstalledBlocks();
+
+        // Self-heal, at most once a minute: delete any reject route on a client
+        // address that is NOT currently meant to be blocked. The loop above
+        // only touches routes this process tracks; this also clears an orphan
+        // left by a killed daemon, so no route can strand a device for more
+        // than about a minute even while the daemon runs on without restarting.
+        // It never deletes a wanted block (those IPs are skipped), and if the
+        // list read ever came back short it errs toward giving a device its
+        // connection back rather than cutting one off — the safe direction.
+        static NSDate *lastHeal;
+        NSDate *now = [NSDate date];
+        if (!lastHeal || [now timeIntervalSinceDate:lastHeal] >= 60.0) {
+            lastHeal = now;
+            NSSet *keep = [NSSet setWithArray:[desired allValues]];
+            for (int host = 2; host <= 14; host++) {
+                NSString *ip = [NSString stringWithFormat:@"172.20.10.%d", host];
+                if (![keep containsObject:ip]) HPSetRouteBlock(ip, NO);
+            }
+        }
     } @catch (NSException *e) {
         HPDaemonLog(@"blocklist apply failed: %@", e);
     }

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -153,41 +153,6 @@ static NSArray *HPLiveConnectedDevices(void) {
     return HPCopyPresentDevices(HPHotspotInterfaceNames(ifaces)) ?: @[];
 }
 
-/// How long a device may be quiet before its row says so.
-///
-/// A third of whatever window is currently deciding presence, so the note is an
-/// early warning that this row is heading for the section below rather than an
-/// unrelated number: while the daemon is probing every 10s it means "missed at
-/// least one question", and while it is only listening it means "quiet for a
-/// while, which is normal". Tied to the window rather than fixed, because a
-/// fixed 60s would never once appear inside the 45s probed window.
-static NSTimeInterval HPIdleAfter(void) {
-    return (HPDaemonIsProbing() ? HPSilentCutoffProbed : HPSilentCutoff) / 3.0;
-}
-
-/// "40s", "6m", "2h 5m" — enough to judge staleness at a glance, no more.
-static NSString *HPShortAge(NSTimeInterval seconds) {
-    if (seconds < 0) seconds = 0;
-    if (seconds < 90) return [NSString stringWithFormat:@"%.0fs", seconds];
-    long minutes = (long)(seconds / 60.0);
-    if (minutes < 60) return [NSString stringWithFormat:@"%ldm", minutes];
-    return [NSString stringWithFormat:@"%ldh %ldm", minutes / 60, minutes % 60];
-}
-
-/// The daemon's per-client timestamps, re-read at most once a second. Every
-/// device row asks for these on the same refresh tick and each ask parses a
-/// plist, so without this the pane would parse it once per row per tick.
-static NSDictionary<NSString *, NSDate *> *HPLastSeenCached(void) {
-    static NSDictionary<NSString *, NSDate *> *cached;
-    static NSDate *readAt;
-    NSDate *now = [NSDate date];
-    if (!cached || !readAt || [now timeIntervalSinceDate:readAt] >= 1.0) {
-        cached = HPCopyDaemonLastSeen();
-        readAt = now;
-    }
-    return cached;
-}
-
 /// "Is the hotspot on", smoothed.
 ///
 /// Even with IP forwarding as the primary signal, a status row that samples
@@ -250,26 +215,8 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
 
     NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
     uint64_t bytes = [seen[mac][@"bytes"] unsignedLongLongValue];
-    NSDate *now = [NSDate date];
-
-    // Where the device is, and then how long it has been that way. A client
-    // that is connected but idle says so in place — the row does not simply
-    // stop looking any different from an active one and then, eventually,
-    // vanish into the section below with no explanation.
-    NSMutableString *where = [ip mutableCopy];
-    if ([ip isEqualToString:@"offline"]) {
-        NSDate *last = seen[mac][@"last"];
-        if (last) [where appendFormat:@" %@", HPShortAge([now timeIntervalSinceDate:last])];
-    } else {
-        NSDate *heard = HPLastSeenCached()[mac];
-        NSTimeInterval quiet = heard ? [now timeIntervalSinceDate:heard] : 0;
-        if (heard && quiet >= HPIdleAfter()) {
-            [where appendFormat:@" · idle %@", HPShortAge(quiet)];
-        }
-    }
-
-    if (bytes == 0) return where;
-    return [NSString stringWithFormat:@"%@ · %@", HPFormatBytes(bytes), where];
+    if (bytes == 0) return ip;
+    return [NSString stringWithFormat:@"%@ · %@", HPFormatBytes(bytes), ip];
 }
 
 - (id)seenValue:(PSSpecifier *)spec {
@@ -390,15 +337,29 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     // Live, matching what the rows are built from. Read from the state file
     // instead, this signature would not change when a device left, so the rows
     // would never be rebuilt and the departed device would stay on screen.
+    //
+    // The DISPLAYED name is included, not just the MAC: a row's title is fixed
+    // when the row is built, so a rename only shows once the rows are rebuilt,
+    // and the rebuild only happens when this signature changes. Renaming a
+    // connected device left the old name on screen until it reconnected.
+    NSDictionary *nicknames = HPConfig()[HPCfgNicknamesKey];
+    if (![nicknames isKindOfClass:[NSDictionary class]]) nicknames = @{};
     for (NSDictionary *d in HPLiveConnectedDevices()) {
-        [sig appendFormat:@"%@,", d[HPDevMacKey]];
+        NSString *mac = d[HPDevMacKey] ?: @"";
+        NSString *shown = [nicknames[mac] length] ? nicknames[mac]
+                                                  : (d[HPDevNameKey] ?: @"");
+        [sig appendFormat:@"%@=%@,", mac, shown];
     }
     [sig appendString:@"|"];
 
-    // Offline devices with usage get a row too, so they belong here.
+    // Offline devices with usage get a row too, so they belong here — with the
+    // name they display, for the same rename reason as above.
     NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};
     for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
-        if ([seen[mac][@"bytes"] unsignedLongLongValue] > 0) [sig appendFormat:@"%@,", mac];
+        if ([seen[mac][@"bytes"] unsignedLongLongValue] == 0) continue;
+        NSString *shown = [nicknames[mac] length] ? nicknames[mac]
+                                                  : (seen[mac][@"name"] ?: mac);
+        [sig appendFormat:@"%@=%@,", mac, shown];
     }
     return sig;
 }
@@ -421,24 +382,6 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};
     for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
         [sig appendFormat:@"%@:%@,", mac, seen[mac][@"bytes"]];
-    }
-
-    // The idle and offline notes on the device rows tick with the clock, so
-    // something here has to tick too — otherwise they would freeze at whatever
-    // they read when a byte total last happened to change. Bucketed to five
-    // seconds, and contributing nothing at all until a note is actually being
-    // shown, so a pane full of active devices stays perfectly still.
-    NSDate *now = [NSDate date];
-    NSDictionary<NSString *, NSDate *> *heard = HPCopyDaemonLastSeen();
-    [sig appendString:@"|"];
-    for (NSString *mac in [heard.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
-        NSTimeInterval quiet = [now timeIntervalSinceDate:heard[mac]];
-        if (quiet >= HPIdleAfter()) [sig appendFormat:@"%ld,", (long)(quiet / 5.0)];
-    }
-    for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
-        NSDate *last = seen[mac][@"last"];
-        if (!last || [seen[mac][@"bytes"] unsignedLongLongValue] == 0) continue;
-        [sig appendFormat:@"%ld,", (long)([now timeIntervalSinceDate:last] / 5.0)];
     }
     return sig;
 }

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -142,53 +142,15 @@ static HPSettingsHelper *gHelper;
 ///
 /// Byte totals still come from the state file: those are the collector's to
 /// compute, and only presence needs to be current.
+///
+/// The judgement of which ARP neighbours have actually left lives in the
+/// collector, so that this pane, the summary row on the stock pane and the
+/// refresh signatures all reach the same answer from one piece of code —
+/// three call sites deciding it separately is how the count in the status row
+/// came to contradict the rows underneath it.
 static NSArray *HPLiveConnectedDevices(void) {
     NSArray<NSDictionary *> *ifaces = HPCopyInterfaces();
-    NSArray *arp = HPCopyConnectedDevices(HPHotspotInterfaceNames(ifaces)) ?: @[];
-
-    // The ARP table records that a client was here; it never records that one
-    // left. A departed device's entry simply stops being refreshed and sits
-    // there counting down, so it kept appearing as connected for minutes after
-    // disconnecting. The daemon's tap supplies the missing half: a frame
-    // actually received, with a timestamp. Anything silent for a while is gone.
-    //
-    // rmx_expire looks like it should answer this and does not reliably — how
-    // often the kernel refreshes it is a detail nobody here has measured, and a
-    // wrong guess would hide devices that are genuinely connected.
-    NSDictionary<NSString *, NSDate *> *lastSeen = HPCopyDaemonLastSeen();
-    if (lastSeen.count == 0) return arp;   // no daemon data: unknown, not gone
-
-    // How long a client may go unheard before it is treated as gone. Its last
-    // frame is stamped at the next flush, up to 10s later, so the real delay is
-    // this plus about ten seconds.
-    static const NSTimeInterval kSilentCutoff = 30.0;
-    // How stale the daemon's own heartbeat may be before its silence stops
-    // meaning anything.
-    static const NSTimeInterval kDaemonStale = 30.0;
-    NSDate *now = [NSDate date];
-
-    // Only trust this filter while the daemon is demonstrably capturing: its tap
-    // closes whenever the bridge flaps, and every per-client timestamp then ages
-    // at once, which once hid devices that were connected throughout.
-    //
-    // The gate is the daemon's own flush time, not the freshest per-client
-    // stamp. Those are the same thing until the last client leaves — at which
-    // point traffic stops, every client stamp goes stale together, and a
-    // freshest-stamp gate would switch the filter off exactly when it was needed
-    // and leave the departed device on screen. The flush heartbeat keeps
-    // ticking every 10s regardless of traffic.
-    NSDate *heartbeat = HPDaemonLastFlush();
-    if (!heartbeat || [now timeIntervalSinceDate:heartbeat] > kDaemonStale) return arp;
-    NSMutableArray *present = [NSMutableArray array];
-    for (NSDictionary *dev in arp) {
-        NSDate *seen = lastSeen[dev[HPDevMacKey]];
-        // A MAC the daemon has no record of has usually just joined and not
-        // been flushed yet. Keep it: never invent a departure from silence.
-        if (!seen || [now timeIntervalSinceDate:seen] <= kSilentCutoff) {
-            [present addObject:dev];
-        }
-    }
-    return present;
+    return HPCopyPresentDevices(HPHotspotInterfaceNames(ifaces)) ?: @[];
 }
 
 /// "Is the hotspot on", smoothed.
@@ -278,7 +240,7 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSDictionary *state = HPStateLoad();
     uint64_t total = [state[HPStTotalBytesKey] unsignedLongLongValue];
     NSArray<NSDictionary *> *ifaces = HPCopyInterfaces();
-    NSUInteger devices = HPCopyConnectedDevices(HPHotspotInterfaceNames(ifaces)).count;
+    NSUInteger devices = HPCopyPresentDevices(HPHotspotInterfaceNames(ifaces)).count;
 
     NSString *summary;
     if (devices > 0) {
@@ -400,7 +362,7 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     // byte total happened to change.
     NSArray<NSDictionary *> *ifaces = HPCopyInterfaces();
     [sig appendFormat:@"%d|%lu|", (int)HPHotspotIsActiveSmoothed(ifaces),
-                      (unsigned long)HPCopyConnectedDevices(
+                      (unsigned long)HPCopyPresentDevices(
                           HPHotspotInterfaceNames(ifaces)).count];
 
     NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -902,8 +902,10 @@ static NSArray *HPBuildDeviceRows(void) {
 
     for (NSString *mac in offline) {
         NSDictionary *record = seen[mac];
+        NSString *nick = nicknames[mac];
+        NSString *shown = nick.length ? nick : (record[@"name"] ?: mac);
 
-        PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:record[@"name"] ?: mac
+        PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:shown
                                                           target:helper
                                                              set:NULL
                                                              get:@selector(deviceValue:)
@@ -937,6 +939,7 @@ static BOOL HPViewHoldsFirstResponderFwd(UIView *view);
     NSString *_hpStructure;
     NSString *_hpValues;
     BOOL _hpEnabled;
+    BOOL _hpAppearedOnce;
 }
 
 - (NSArray *)specifiers {
@@ -975,6 +978,17 @@ static BOOL HPViewHoldsFirstResponderFwd(UIView *view);
     [super viewWillAppear:animated];
     @try {
         HPSettingsHelper *helper = [HPSettingsHelper shared];
+
+        // Coming BACK to this pane — e.g. after renaming a device on its own
+        // page — the rows on screen were built before the change. Rebuild them
+        // now so the new name shows at once. Skipped on the very first
+        // appearance, where -specifiers has just built them fresh and the table
+        // is not up yet. Without this, re-baselining the signature just below
+        // made hpTick compare equal-to-equal and never repaint, so a rename
+        // never showed in the list.
+        if (_hpAppearedOnce) [self hpUpdateDeviceRows];
+        _hpAppearedOnce = YES;
+
         _hpStructure = [helper structureSignature];
         _hpValues = [helper valueSignature];
         _hpEnabled = [HPConfig()[HPCfgEnabledKey] boolValue];

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -686,6 +686,34 @@ static NSArray *HPBuildBodySpecifiers(void) {
     return @([limits[[self hpMac]] doubleValue]);
 }
 
+/// The user-set nickname, or empty. The DHCP name a device announces is shown
+/// as a placeholder instead, so the field is not misread as already holding it.
+- (id)hpNameValue:(PSSpecifier *)spec {
+    NSDictionary *nicknames = HPConfig()[HPCfgNicknamesKey];
+    return ([nicknames isKindOfClass:[NSDictionary class]] ? nicknames[[self hpMac]] : nil) ?: @"";
+}
+
+- (void)setHpName:(id)value specifier:(PSSpecifier *)spec {
+    NSMutableDictionary *cfg =
+        [([NSDictionary dictionaryWithContentsOfFile:HPConfigPath()] ?: @{}) mutableCopy];
+    NSMutableDictionary *nicknames = [(cfg[HPCfgNicknamesKey] ?: @{}) mutableCopy];
+
+    NSString *name = [value isKindOfClass:[NSString class]] ? value : nil;
+    name = [name stringByTrimmingCharactersInSet:
+                     [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (name.length) nicknames[[self hpMac]] = name;
+    else [nicknames removeObjectForKey:[self hpMac]];   // cleared: back to the DHCP name
+
+    cfg[HPCfgNicknamesKey] = nicknames;
+    [cfg writeToFile:HPConfigPath() atomically:YES];
+
+    // The nickname is baked into device rows and the "seen this period" record
+    // by the collector, so a tick rebuilds them under the new name; do it now
+    // rather than waiting for the next sample.
+    self.title = name.length ? name : [self hpMac];
+    HPPostTickRequest();
+}
+
 - (void)setHpDeviceLimit:(id)value specifier:(PSSpecifier *)spec {
     NSMutableDictionary *cfg =
         [([NSDictionary dictionaryWithContentsOfFile:HPConfigPath()] ?: @{}) mutableCopy];
@@ -713,10 +741,23 @@ static NSArray *HPBuildBodySpecifiers(void) {
 }
 
 - (id)hpStatusValue:(PSSpecifier *)spec {
-    NSArray *blocked = HPStateLoad()[HPStBlockedMacsKey] ?: @[];
-    if ([blocked containsObject:[self hpMac]]) return @"Blocked — over its limit";
+    NSString *mac = [self hpMac];
+    BOOL wantBlocked = [(HPStateLoad()[HPStBlockedMacsKey] ?: @[]) containsObject:mac];
 
-    double limit = [HPConfig()[HPCfgDeviceLimitsKey][[self hpMac]] doubleValue];
+    if (wantBlocked) {
+        // "Blocked" is a claim about the routing table, and only the daemon
+        // touches that. Say it is blocked only when the daemon confirms the
+        // route is in and its heartbeat is recent; otherwise be honest that the
+        // device is over its limit but still has a working connection, which is
+        // what a dead or route-less daemon leaves behind.
+        BOOL enforced = [HPDaemonBlockedMacs() containsObject:mac];
+        NSDate *flush = HPDaemonLastFlush();
+        BOOL daemonAlive = flush && [[NSDate date] timeIntervalSinceDate:flush] <= 60.0;
+        if (enforced && daemonAlive) return @"Blocked — over its limit";
+        return @"Over limit — not enforced (helper not running)";
+    }
+
+    double limit = [HPConfig()[HPCfgDeviceLimitsKey][mac] doubleValue];
     return limit > 0 ? @"Allowed" : @"No limit set";
 }
 
@@ -734,6 +775,27 @@ static NSArray *HPBuildBodySpecifiers(void) {
     }
 
     NSMutableArray *specs = [NSMutableArray array];
+
+    [specs addObject:HPGroup(@"NAME", @"A name for this device in the list above. "
+                                       "Leave it blank to use the name the device "
+                                       "reports for itself.")];
+    PSSpecifier *name = [PSSpecifier preferenceSpecifierNamed:@"Name"
+                                                       target:self
+                                                          set:@selector(setHpName:specifier:)
+                                                          get:@selector(hpNameValue:)
+                                                       detail:nil
+                                                         cell:PSEditTextCell
+                                                         edit:nil];
+    // The DHCP name shown when nothing is set, so the field reads as a rename
+    // rather than an empty box.
+    NSDictionary *seenNow = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
+    NSString *dhcpName = seenNow[[self hpMac]][@"name"];
+    if (dhcpName.length && ![dhcpName isEqualToString:[self hpMac]]) {
+        [name setProperty:dhcpName forKey:@"placeholder"];
+    } else {
+        [name setProperty:@"Device name" forKey:@"placeholder"];
+    }
+    [specs addObject:name];
 
     [specs addObject:HPGroup(@"THIS PERIOD", nil)];
     PSSpecifier *used = [PSSpecifier preferenceSpecifierNamed:@"Used"
@@ -819,8 +881,11 @@ static NSArray *HPBuildBodySpecifiers(void) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     @try {
+        NSDictionary *nicknames = HPConfig()[HPCfgNicknamesKey];
+        NSString *nick = [nicknames isKindOfClass:[NSDictionary class]]
+                             ? nicknames[[self hpMac]] : nil;
         NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
-        self.title = seen[[self hpMac]][@"name"] ?: [self hpMac];
+        self.title = nick.length ? nick : (seen[[self hpMac]][@"name"] ?: [self hpMac]);
     } @catch (NSException *e) {}
 }
 
@@ -834,10 +899,20 @@ static NSArray *HPBuildDeviceRows(void) {
     NSMutableArray *specs = [NSMutableArray array];
     NSArray *devices = HPLiveConnectedDevices();
 
+    // A nickname the user set on a device's own page wins over the name the
+    // device announces over DHCP — which for a client with a randomised MAC is
+    // often missing entirely. The collector applies the same preference to the
+    // "seen this period" record, so a renamed device reads the same whether it
+    // is connected now (this list) or offline (the list below).
+    NSDictionary *nicknames = HPConfig()[HPCfgNicknamesKey];
+    if (![nicknames isKindOfClass:[NSDictionary class]]) nicknames = @{};
+
     for (NSDictionary *dev in devices) {
+        NSString *nick = nicknames[dev[HPDevMacKey]];
+        NSString *shown = nick.length ? nick : (dev[HPDevNameKey] ?: @"Device");
         // Built with a getter like every other value row, rather than a static
         // "value" property, which a PSTitleValueCell does not reliably display.
-        PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:dev[HPDevNameKey] ?: @"Device"
+        PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:shown
                                                           target:helper
                                                              set:NULL
                                                              get:@selector(deviceValue:)

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -754,7 +754,14 @@ static NSArray *HPBuildBodySpecifiers(void) {
         NSDate *flush = HPDaemonLastFlush();
         BOOL daemonAlive = flush && [[NSDate date] timeIntervalSinceDate:flush] <= 60.0;
         if (enforced && daemonAlive) return @"Blocked — over its limit";
-        return @"Over limit — not enforced (helper not running)";
+        // Not actually cut off. Name why, from the daemon's own breadcrumb, so
+        // this is a lead rather than a dead end.
+        NSString *state = HPCopyDaemonStatus()[@"state"];
+        NSString *why = @"helper not running";
+        if ([state isEqualToString:@"gated-ios18"])   why = @"unsupported on iOS 18";
+        else if ([state isEqualToString:@"tracking-off"]) why = @"tracking is off";
+        else if ([state isEqualToString:@"no-bpf"])   why = @"helper can't capture";
+        return [NSString stringWithFormat:@"Over limit — not enforced (%@)", why];
     }
 
     double limit = [HPConfig()[HPCfgDeviceLimitsKey][mac] doubleValue];

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -153,6 +153,41 @@ static NSArray *HPLiveConnectedDevices(void) {
     return HPCopyPresentDevices(HPHotspotInterfaceNames(ifaces)) ?: @[];
 }
 
+/// How long a device may be quiet before its row says so.
+///
+/// A third of whatever window is currently deciding presence, so the note is an
+/// early warning that this row is heading for the section below rather than an
+/// unrelated number: while the daemon is probing every 10s it means "missed at
+/// least one question", and while it is only listening it means "quiet for a
+/// while, which is normal". Tied to the window rather than fixed, because a
+/// fixed 60s would never once appear inside the 45s probed window.
+static NSTimeInterval HPIdleAfter(void) {
+    return (HPDaemonIsProbing() ? HPSilentCutoffProbed : HPSilentCutoff) / 3.0;
+}
+
+/// "40s", "6m", "2h 5m" — enough to judge staleness at a glance, no more.
+static NSString *HPShortAge(NSTimeInterval seconds) {
+    if (seconds < 0) seconds = 0;
+    if (seconds < 90) return [NSString stringWithFormat:@"%.0fs", seconds];
+    long minutes = (long)(seconds / 60.0);
+    if (minutes < 60) return [NSString stringWithFormat:@"%ldm", minutes];
+    return [NSString stringWithFormat:@"%ldh %ldm", minutes / 60, minutes % 60];
+}
+
+/// The daemon's per-client timestamps, re-read at most once a second. Every
+/// device row asks for these on the same refresh tick and each ask parses a
+/// plist, so without this the pane would parse it once per row per tick.
+static NSDictionary<NSString *, NSDate *> *HPLastSeenCached(void) {
+    static NSDictionary<NSString *, NSDate *> *cached;
+    static NSDate *readAt;
+    NSDate *now = [NSDate date];
+    if (!cached || !readAt || [now timeIntervalSinceDate:readAt] >= 1.0) {
+        cached = HPCopyDaemonLastSeen();
+        readAt = now;
+    }
+    return cached;
+}
+
 /// "Is the hotspot on", smoothed.
 ///
 /// Even with IP forwarding as the primary signal, a status row that samples
@@ -215,8 +250,26 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
 
     NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
     uint64_t bytes = [seen[mac][@"bytes"] unsignedLongLongValue];
-    if (bytes == 0) return ip;
-    return [NSString stringWithFormat:@"%@ · %@", HPFormatBytes(bytes), ip];
+    NSDate *now = [NSDate date];
+
+    // Where the device is, and then how long it has been that way. A client
+    // that is connected but idle says so in place — the row does not simply
+    // stop looking any different from an active one and then, eventually,
+    // vanish into the section below with no explanation.
+    NSMutableString *where = [ip mutableCopy];
+    if ([ip isEqualToString:@"offline"]) {
+        NSDate *last = seen[mac][@"last"];
+        if (last) [where appendFormat:@" %@", HPShortAge([now timeIntervalSinceDate:last])];
+    } else {
+        NSDate *heard = HPLastSeenCached()[mac];
+        NSTimeInterval quiet = heard ? [now timeIntervalSinceDate:heard] : 0;
+        if (heard && quiet >= HPIdleAfter()) {
+            [where appendFormat:@" · idle %@", HPShortAge(quiet)];
+        }
+    }
+
+    if (bytes == 0) return where;
+    return [NSString stringWithFormat:@"%@ · %@", HPFormatBytes(bytes), where];
 }
 
 - (id)seenValue:(PSSpecifier *)spec {
@@ -368,6 +421,24 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};
     for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
         [sig appendFormat:@"%@:%@,", mac, seen[mac][@"bytes"]];
+    }
+
+    // The idle and offline notes on the device rows tick with the clock, so
+    // something here has to tick too — otherwise they would freeze at whatever
+    // they read when a byte total last happened to change. Bucketed to five
+    // seconds, and contributing nothing at all until a note is actually being
+    // shown, so a pane full of active devices stays perfectly still.
+    NSDate *now = [NSDate date];
+    NSDictionary<NSString *, NSDate *> *heard = HPCopyDaemonLastSeen();
+    [sig appendString:@"|"];
+    for (NSString *mac in [heard.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
+        NSTimeInterval quiet = [now timeIntervalSinceDate:heard[mac]];
+        if (quiet >= HPIdleAfter()) [sig appendFormat:@"%ld,", (long)(quiet / 5.0)];
+    }
+    for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
+        NSDate *last = seen[mac][@"last"];
+        if (!last || [seen[mac][@"bytes"] unsignedLongLongValue] == 0) continue;
+        [sig appendFormat:@"%ld,", (long)([now timeIntervalSinceDate:last] / 5.0)];
     }
     return sig;
 }

--- a/src/Tracker.m
+++ b/src/Tracker.m
@@ -114,7 +114,16 @@ NSDictionary *HPTick(void) {
     state[HPStIfNamesKey]    = names;
 
     // --- devices -----------------------------------------------------------
+    // Two lists, deliberately: the ARP table is what a device has *been* seen
+    // at, and that is what the "seen this period" record wants — a name and an
+    // address are worth keeping the moment they are known. "Connected now" is a
+    // narrower question, and only HPCopyPresentDevices() answers it, so the CLI
+    // and the Settings pane cannot end up disagreeing about who is here.
     NSArray<NSDictionary *> *devices = HPCopyConnectedDevices(names);
+    NSMutableSet<NSString *> *presentMacs = [NSMutableSet set];
+    for (NSDictionary *dev in HPCopyPresentDevices(names)) {
+        if (dev[HPDevMacKey]) [presentMacs addObject:dev[HPDevMacKey]];
+    }
     NSDictionary *nicknames = cfg[HPCfgNicknamesKey];
 
     NSMutableArray *devicesNow = [NSMutableArray array];
@@ -129,7 +138,7 @@ NSDictionary *HPTick(void) {
         NSString *nick = [nicknames isKindOfClass:[NSDictionary class]] ? nicknames[mac] : nil;
         if (nick.length) entry[HPDevNameKey] = nick;
         if (!entry[HPDevNameKey]) entry[HPDevNameKey] = mac;
-        [devicesNow addObject:entry];
+        if ([presentMacs containsObject:mac]) [devicesNow addObject:entry];
 
         NSMutableDictionary *record = [(seen[mac] ?: @{}) mutableCopy];
         if (!record[@"first"]) record[@"first"] = now;

--- a/src/main.m
+++ b/src/main.m
@@ -107,6 +107,12 @@ static void HPCommandDump(void) {
             flush ? [NSString stringWithFormat:@"%.0fs ago",
                               [now timeIntervalSinceDate:flush]]
                   : @"never (daemon not running?)");
+    // Which of the two windows is in force, and why.
+    BOOL probing = HPDaemonIsProbing();
+    HPPrint(@"Probing      : %@ (window %.0fs)",
+            probing ? @"yes, ARP request per client every 10s"
+                    : @"no — passive, nothing is being asked",
+            probing ? HPSilentCutoffProbed : HPSilentCutoff);
     if (lastSeen.count == 0) {
         HPPrint(@"No per-client timestamps — nothing can be ruled offline.");
     }
@@ -295,8 +301,10 @@ static int HPCommandSelftest(void) {
                      HPDevExpiresKey : expire } ];
     };
     NSArray *arp = arpWithExpire(@1000);
-    // A tap that has been open far longer than the window, so silence counts.
+    // A tap that has been open far longer than either window, so silence counts.
     NSDate *tapSince = at(-10 * HPSilentCutoff);
+    // Nothing heard from this client since long before the window began.
+    NSDictionary *longAgo = @{ quiet : at(-10 * HPSilentCutoff) };
 
     void (^expect)(NSString *, NSUInteger, NSUInteger) =
         ^(NSString *what, NSUInteger got, NSUInteger want) {
@@ -313,18 +321,18 @@ static int HPCommandSelftest(void) {
     NSMutableDictionary *books = [NSMutableDictionary dictionary];
     expect(@"a client heard 10s ago is present",
            HPFilterPresentDevices(arp, @{ quiet : at(-10) }, tapSince, at(0),
-                                  books, at(0)).count, 1);
+                                  NO, books, at(0)).count, 1);
 
-    // Regression: an idle client, silent past the window, whose ARP entry the
-    // kernel is still refreshing. Under the old rule this device vanished from
-    // the list and came back on its next packet; the refreshed expiry is
-    // independent evidence that it is still reachable.
+    // Regression, the bug itself: an idle client, silent past the passive
+    // window, whose ARP entry the kernel is still refreshing. Under the old
+    // rule this device vanished from the list and came back on its next packet;
+    // the refreshed expiry is independent evidence that it is still reachable.
     books = [NSMutableDictionary dictionary];
-    NSDictionary *longAgo = @{ quiet : at(-10 * HPSilentCutoff) };
-    HPFilterPresentDevices(arpWithExpire(@1000), longAgo, tapSince, at(0), books, at(0));
+    HPFilterPresentDevices(arpWithExpire(@1000), longAgo, tapSince, at(0),
+                           NO, books, at(0));
     for (int i = 1; i <= HPMissesNeeded + 1; i++) {
         NSArray *out = HPFilterPresentDevices(arpWithExpire(@(1000 + i * 30)), longAgo,
-                                              tapSince, at(i), books, at(i));
+                                              tapSince, at(i), NO, books, at(i));
         if (out.count != 1) {
             HPPrint(@"  FAIL  idle client with a refreshed ARP entry dropped on poll %d", i);
             failures++;
@@ -339,44 +347,63 @@ static int HPCommandSelftest(void) {
     books = [NSMutableDictionary dictionary];
     for (int i = 1; i < HPMissesNeeded; i++) {
         expect([NSString stringWithFormat:@"silent poll %d does not drop it", i],
-               HPFilterPresentDevices(arp, longAgo, tapSince, at(i), books, at(i)).count, 1);
+               HPFilterPresentDevices(arp, longAgo, tapSince, at(i),
+                                      NO, books, at(i)).count, 1);
     }
     // ...but a client with nothing to show for itself, poll after poll, is gone.
     expect(@"a client silent past the window is dropped",
            HPFilterPresentDevices(arp, longAgo, tapSince, at(HPMissesNeeded),
-                                  books, at(HPMissesNeeded)).count, 0);
+                                  NO, books, at(HPMissesNeeded)).count, 0);
+
+    // Probing shortens the window without changing the rule: silence in the
+    // face of unanswered ARP requests means more than silence alone.
+    NSDictionary *quietAWhile = @{ quiet : at(-2 * HPSilentCutoffProbed) };
+    books = [NSMutableDictionary dictionary];
+    for (int i = 0; i <= HPMissesNeeded; i++) {
+        HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0), NO, books, at(i));
+    }
+    expect(@"90s of silence is not a departure when nobody is asking",
+           HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0),
+                                  NO, books, at(HPMissesNeeded + 1)).count, 1);
+    books = [NSMutableDictionary dictionary];
+    for (int i = 0; i < HPMissesNeeded; i++) {
+        HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0), YES, books, at(i));
+    }
+    expect(@"...but it is when the client has been asked and did not answer",
+           HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0),
+                                  YES, books, at(HPMissesNeeded)).count, 0);
 
     // The gates that must switch the rule off entirely: silence proves nothing
     // when nothing was listening.
     books = [NSMutableDictionary dictionary];
     for (int i = 0; i <= HPMissesNeeded; i++) {
-        HPFilterPresentDevices(arp, longAgo, at(-1), at(0), books, at(i));
+        HPFilterPresentDevices(arp, longAgo, at(-1), at(0), NO, books, at(i));
     }
     expect(@"a tap open for less than the window rules nobody out",
            HPFilterPresentDevices(arp, longAgo, at(-1), at(0),
-                                  books, at(HPMissesNeeded + 1)).count, 1);
+                                  NO, books, at(HPMissesNeeded + 1)).count, 1);
 
     books = [NSMutableDictionary dictionary];
     for (int i = 0; i <= HPMissesNeeded; i++) {
-        HPFilterPresentDevices(arp, longAgo, tapSince,
-                               at(-2 * HPDaemonStaleAfter), books, at(i));
+        HPFilterPresentDevices(arp, longAgo, tapSince, at(-2 * HPDaemonStaleAfter),
+                               NO, books, at(i));
     }
     expect(@"a stale daemon heartbeat rules nobody out",
            HPFilterPresentDevices(arp, longAgo, tapSince, at(-2 * HPDaemonStaleAfter),
-                                  books, at(HPMissesNeeded + 1)).count, 1);
+                                  NO, books, at(HPMissesNeeded + 1)).count, 1);
 
     books = [NSMutableDictionary dictionary];
     for (int i = 0; i <= HPMissesNeeded; i++) {
-        HPFilterPresentDevices(arp, @{}, tapSince, at(0), books, at(i));
+        HPFilterPresentDevices(arp, @{}, tapSince, at(0), NO, books, at(i));
     }
     expect(@"no daemon data at all rules nobody out",
            HPFilterPresentDevices(arp, @{}, tapSince, at(0),
-                                  books, at(HPMissesNeeded + 1)).count, 1);
+                                  NO, books, at(HPMissesNeeded + 1)).count, 1);
 
     // Bookkeeping must not accumulate a row per randomised MAC forever.
     books = [NSMutableDictionary dictionary];
-    HPFilterPresentDevices(arp, longAgo, tapSince, at(0), books, at(0));
-    HPFilterPresentDevices(@[], longAgo, tapSince, at(1), books, at(1));
+    HPFilterPresentDevices(arp, longAgo, tapSince, at(0), NO, books, at(0));
+    HPFilterPresentDevices(@[], longAgo, tapSince, at(1), NO, books, at(1));
     NSUInteger left = 0;
     for (NSString *k in books) left += [books[k] count];
     expect(@"bookkeeping is forgotten with the ARP entry", left, 0);

--- a/src/main.m
+++ b/src/main.m
@@ -88,6 +88,36 @@ static void HPCommandDump(void) {
                 [(d[HPDevIPKey] ?: @"?") UTF8String],
                 d[HPDevMacKey]);
     }
+
+    // The evidence behind "who is here now", printed raw. The list above is the
+    // ARP table, which keeps a departed client's entry for the rest of its
+    // lifetime; whether a device is shown as connected or as offline turns on
+    // the numbers below, so this is the section to read when a device that is
+    // plainly connected is being reported as offline.
+    NSDate *now = [NSDate date];
+    NSDate *tapSince = HPDaemonTapSince();
+    NSDate *flush = HPDaemonLastFlush();
+    NSDictionary<NSString *, NSDate *> *lastSeen = HPCopyDaemonLastSeen();
+    HPPrint(@"\n=== daemon presence evidence ===");
+    HPPrint(@"Tap open for : %@",
+            tapSince ? [NSString stringWithFormat:@"%.0fs",
+                                 [now timeIntervalSinceDate:tapSince]]
+                     : @"no tap open");
+    HPPrint(@"Last flush   : %@",
+            flush ? [NSString stringWithFormat:@"%.0fs ago",
+                              [now timeIntervalSinceDate:flush]]
+                  : @"never (daemon not running?)");
+    if (lastSeen.count == 0) {
+        HPPrint(@"No per-client timestamps — nothing can be ruled offline.");
+    }
+    for (NSString *mac in lastSeen) {
+        HPPrint(@"  %-20s last frame %.0fs ago",
+                [mac UTF8String], [now timeIntervalSinceDate:lastSeen[mac]]);
+    }
+
+    // Deliberately no verdict here. HPCopyPresentDevices() reaches one across
+    // successive polls, so a one-shot process cannot ask it a fair question;
+    // `hotspotpro status` reads the collector's answer, which was.
 }
 
 #pragma mark - watch
@@ -247,6 +277,110 @@ static int HPCommandSelftest(void) {
     HPPrint(@"  '1,1e:7:67:bb:5b:3f' -> '%@'", mac);
     if (![mac isEqualToString:@"1e:07:67:bb:5b:3f"]) failures++;
 
+    // --- presence ----------------------------------------------------------
+    // Whether a connected device is shown as connected. The bug this pins is a
+    // device that never left being reported offline and then online again: the
+    // rule used to be "no captured frame in 30s means gone", and an idle client
+    // is silent for far longer than that.
+    HPPrint(@"\n=== presence ===");
+    NSString *quiet = @"aa:bb:cc:dd:ee:01";
+    NSDate *t0 = [NSDate dateWithTimeIntervalSince1970:1700000000];
+    NSDate *(^at)(NSTimeInterval) = ^(NSTimeInterval dt) {
+        return [t0 dateByAddingTimeInterval:dt];
+    };
+    NSArray *(^arpWithExpire)(NSNumber *) = ^(NSNumber *expire) {
+        return @[ @{ HPDevMacKey     : quiet,
+                     HPDevIPKey      : @"172.20.10.5",
+                     HPDevIfNameKey  : @"bridge100",
+                     HPDevExpiresKey : expire } ];
+    };
+    NSArray *arp = arpWithExpire(@1000);
+    // A tap that has been open far longer than the window, so silence counts.
+    NSDate *tapSince = at(-10 * HPSilentCutoff);
+
+    void (^expect)(NSString *, NSUInteger, NSUInteger) =
+        ^(NSString *what, NSUInteger got, NSUInteger want) {
+            if (got == want) {
+                HPPrint(@"  ok    %@ (%lu)", what, (unsigned long)got);
+            } else {
+                HPPrint(@"  FAIL  %@: got %lu, want %lu", what,
+                        (unsigned long)got, (unsigned long)want);
+                failures++;
+            }
+        };
+
+    // Heard recently: present, however long ago anything else happened.
+    NSMutableDictionary *books = [NSMutableDictionary dictionary];
+    expect(@"a client heard 10s ago is present",
+           HPFilterPresentDevices(arp, @{ quiet : at(-10) }, tapSince, at(0),
+                                  books, at(0)).count, 1);
+
+    // Regression: an idle client, silent past the window, whose ARP entry the
+    // kernel is still refreshing. Under the old rule this device vanished from
+    // the list and came back on its next packet; the refreshed expiry is
+    // independent evidence that it is still reachable.
+    books = [NSMutableDictionary dictionary];
+    NSDictionary *longAgo = @{ quiet : at(-10 * HPSilentCutoff) };
+    HPFilterPresentDevices(arpWithExpire(@1000), longAgo, tapSince, at(0), books, at(0));
+    for (int i = 1; i <= HPMissesNeeded + 1; i++) {
+        NSArray *out = HPFilterPresentDevices(arpWithExpire(@(1000 + i * 30)), longAgo,
+                                              tapSince, at(i), books, at(i));
+        if (out.count != 1) {
+            HPPrint(@"  FAIL  idle client with a refreshed ARP entry dropped on poll %d", i);
+            failures++;
+            break;
+        }
+        if (i == HPMissesNeeded + 1) {
+            HPPrint(@"  ok    an idle client the kernel still reaches stays present");
+        }
+    }
+
+    // One silent poll is not a departure, and neither are two.
+    books = [NSMutableDictionary dictionary];
+    for (int i = 1; i < HPMissesNeeded; i++) {
+        expect([NSString stringWithFormat:@"silent poll %d does not drop it", i],
+               HPFilterPresentDevices(arp, longAgo, tapSince, at(i), books, at(i)).count, 1);
+    }
+    // ...but a client with nothing to show for itself, poll after poll, is gone.
+    expect(@"a client silent past the window is dropped",
+           HPFilterPresentDevices(arp, longAgo, tapSince, at(HPMissesNeeded),
+                                  books, at(HPMissesNeeded)).count, 0);
+
+    // The gates that must switch the rule off entirely: silence proves nothing
+    // when nothing was listening.
+    books = [NSMutableDictionary dictionary];
+    for (int i = 0; i <= HPMissesNeeded; i++) {
+        HPFilterPresentDevices(arp, longAgo, at(-1), at(0), books, at(i));
+    }
+    expect(@"a tap open for less than the window rules nobody out",
+           HPFilterPresentDevices(arp, longAgo, at(-1), at(0),
+                                  books, at(HPMissesNeeded + 1)).count, 1);
+
+    books = [NSMutableDictionary dictionary];
+    for (int i = 0; i <= HPMissesNeeded; i++) {
+        HPFilterPresentDevices(arp, longAgo, tapSince,
+                               at(-2 * HPDaemonStaleAfter), books, at(i));
+    }
+    expect(@"a stale daemon heartbeat rules nobody out",
+           HPFilterPresentDevices(arp, longAgo, tapSince, at(-2 * HPDaemonStaleAfter),
+                                  books, at(HPMissesNeeded + 1)).count, 1);
+
+    books = [NSMutableDictionary dictionary];
+    for (int i = 0; i <= HPMissesNeeded; i++) {
+        HPFilterPresentDevices(arp, @{}, tapSince, at(0), books, at(i));
+    }
+    expect(@"no daemon data at all rules nobody out",
+           HPFilterPresentDevices(arp, @{}, tapSince, at(0),
+                                  books, at(HPMissesNeeded + 1)).count, 1);
+
+    // Bookkeeping must not accumulate a row per randomised MAC forever.
+    books = [NSMutableDictionary dictionary];
+    HPFilterPresentDevices(arp, longAgo, tapSince, at(0), books, at(0));
+    HPFilterPresentDevices(@[], longAgo, tapSince, at(1), books, at(1));
+    NSUInteger left = 0;
+    for (NSString *k in books) left += [books[k] count];
+    expect(@"bookkeeping is forgotten with the ARP entry", left, 0);
+
     return failures;
 }
 
@@ -286,7 +420,8 @@ static void HPCommandClasses(void) {
 
 static void HPUsage(void) {
     HPPrint(@"hotspotpro — Personal Hotspot usage, devices and limits\n");
-    HPPrint(@"  dump              interfaces, counters, arp, leases, devices");
+    HPPrint(@"  dump              interfaces, counters, arp, leases, devices,");
+    HPPrint(@"                    and the evidence behind who counts as present");
     HPPrint(@"  watch [secs] [--log]  per-interval deltas (default 5) — the measurement");
     HPPrint(@"  tick              take one sample and fold it into state");
     HPPrint(@"  status            current period, limit and devices");

--- a/src/main.m
+++ b/src/main.m
@@ -98,6 +98,21 @@ static void HPCommandDump(void) {
     NSDate *tapSince = HPDaemonTapSince();
     NSDate *flush = HPDaemonLastFlush();
     NSDictionary<NSString *, NSDate *> *lastSeen = HPCopyDaemonLastSeen();
+    // The daemon's own account of itself. Read this first when per-device
+    // numbers or blocking are missing: it says whether the helper is running
+    // and, if it is, why it might be doing nothing.
+    NSDictionary *daemon = HPCopyDaemonStatus();
+    HPPrint(@"\n=== daemon ===");
+    if (!daemon) {
+        HPPrint(@"No status file — the helper has never run on this device.");
+        HPPrint(@"Check:  launchctl print system/com.dangkhoa.hotspotpro");
+    } else {
+        HPPrint(@"State    : %@", daemon[@"state"] ?: @"?");
+        HPPrint(@"PID      : %@", daemon[@"pid"] ?: @"?");
+        HPPrint(@"Firmware : %@", daemon[@"firmware"] ?: @"?");
+        HPPrint(@"As of    : %@", daemon[@"updated"] ?: @"?");
+    }
+
     HPPrint(@"\n=== daemon presence evidence ===");
     HPPrint(@"Tap open for : %@",
             tapSince ? [NSString stringWithFormat:@"%.0fs",

--- a/src/main.m
+++ b/src/main.m
@@ -370,23 +370,22 @@ static int HPCommandSelftest(void) {
            HPFilterPresentDevices(arp, longAgo, tapSince, at(HPMissesNeeded),
                                   NO, books, at(HPMissesNeeded)).count, 0);
 
-    // Probing shortens the window without changing the rule: silence in the
-    // face of unanswered ARP requests means more than silence alone.
-    NSDictionary *quietAWhile = @{ quiet : at(-2 * HPSilentCutoffProbed) };
-    books = [NSMutableDictionary dictionary];
-    for (int i = 0; i <= HPMissesNeeded; i++) {
-        HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0), NO, books, at(i));
+    // Presence uses the conservative window whether or not the daemon is
+    // probing: an idle device that is silent for a couple of minutes is still
+    // connected, and shortening the window on the strength of probes that may
+    // not draw a reply on a given device was hiding connected devices. So the
+    // same silence is not a departure under either flag.
+    NSDictionary *quietAWhile = @{ quiet : at(-120) };   // 2 min, inside the 4-min window
+    for (int flag = 0; flag <= 1; flag++) {
+        books = [NSMutableDictionary dictionary];
+        for (int i = 0; i <= HPMissesNeeded; i++) {
+            HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0), flag, books, at(i));
+        }
+        expect(flag ? @"2 min silent stays present even while probing"
+                    : @"2 min silent stays present when not probing",
+               HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0),
+                                      flag, books, at(HPMissesNeeded + 1)).count, 1);
     }
-    expect(@"90s of silence is not a departure when nobody is asking",
-           HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0),
-                                  NO, books, at(HPMissesNeeded + 1)).count, 1);
-    books = [NSMutableDictionary dictionary];
-    for (int i = 0; i < HPMissesNeeded; i++) {
-        HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0), YES, books, at(i));
-    }
-    expect(@"...but it is when the client has been asked and did not answer",
-           HPFilterPresentDevices(arp, quietAWhile, tapSince, at(0),
-                                  YES, books, at(HPMissesNeeded)).count, 0);
 
     // The gates that must switch the rule off entirely: silence proves nothing
     // when nothing was listening.

--- a/tools/repo-build-beta.sh
+++ b/tools/repo-build-beta.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Generate the BETA channel: a second, opt-in APT repo under docs/beta/.
+#
+#   ./repo-build-beta.sh [https://YOURNAME.github.io/HotspotPro]
+#
+# The point of a separate channel is that it is discoverable without being
+# forced on anyone. The stable repo lives at docs/ and everyone who added the
+# main URL keeps getting stable releases; the beta lives at docs/beta/ and only
+# someone who adds the .../beta/ URL ever sees a beta. The two indexes are
+# independent files under one Pages site, so publishing a beta never touches a
+# single byte the stable users fetch.
+#
+# It is deliberately NOT repo-build.sh with a flag: that script guards that the
+# depiction changelog matches the released version, serves debs from counted
+# GitHub release assets, and writes the top-level index. A beta wants none of
+# that — its version is ahead of the changelog by definition, its debs are
+# sideload artifacts nobody is counting, and it must not overwrite the stable
+# landing page. Keeping them apart means a beta build can never clobber stable.
+#
+# Everything here is regenerated from release/*.deb, so the flow is: download
+# the debs the macOS build produced for the beta branch into release/, then run
+# this. The debs are served straight from docs/beta/debs/ (relative Filename),
+# not from a GitHub release — a beta is not something to cut a tag for.
+set -e
+
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Arg 1 (or repo-url.txt) is the MAIN site base; the beta channel hangs off it.
+MAIN_BASE="${1:-$(cat "$SRC/repo-url.txt" 2>/dev/null || echo "https://dangkhoa116.github.io/hotspotpro")}"
+MAIN_BASE="${MAIN_BASE%/}"
+BASE_URL="$MAIN_BASE/beta"
+GITHUB="${GITHUB_URL:-$(cat "$SRC/github-url.txt" 2>/dev/null || echo "https://github.com/dangkhoa116/hotspotpro")}"
+
+# Where the beta repo is written. Overridable so the generator can be dry-run
+# into a throwaway directory without touching the tree that gets committed.
+DOCS="${HP_BETA_DOCS:-$SRC/docs/beta}"
+DEBS="$DOCS/debs"
+
+if ! ls "$SRC"/release/*.deb >/dev/null 2>&1; then
+    echo "no packages in release/ — download the beta build's debs into release/ first"
+    exit 1
+fi
+
+# The version describes the debs being published, so read it from a deb rather
+# than from control — that way this runs correctly from any branch (master
+# included) against whatever beta debs were downloaded into release/, instead of
+# only from the branch whose control happens to carry the beta stamp.
+VERSION="$(dpkg-deb -f "$(ls "$SRC"/release/*.deb | head -1)" Version)"
+case "$VERSION" in
+    *"~"*|*beta*|*rc*) : ;;   # a pre-release version, as a beta should carry
+    *) echo "the debs in release/ are version '$VERSION', which is not a"
+       echo "pre-release. A beta should be stamped e.g. 0.6.8~beta1 so it never"
+       echo "outranks a real release. Refusing to build a beta channel from it."
+       exit 1 ;;
+esac
+
+mkdir -p "$DEBS"
+rm -f "$DEBS"/*.deb
+cp -f "$SRC"/release/*.deb "$DEBS"/
+cp -f "$SRC"/assets/icon.png "$DOCS"/CydiaIcon.png
+
+# Render the web templates into the beta channel, stamped with the beta URL and
+# version. A visible BETA banner is injected so nobody mistakes this channel for
+# stable, and the "Add to Sileo" button already follows @BASE_URL@ to the beta
+# URL. donate.html is not carried: a test channel has no tip jar.
+for template in "$SRC"/web/index.html "$SRC"/web/depiction.html "$SRC"/web/depiction.json; do
+    [ -f "$template" ] || continue
+    name="$(basename "$template")"
+    sed -e "s|@BASE_URL@|$BASE_URL|g" \
+        -e "s|@GITHUB@|$GITHUB|g" \
+        -e "s|@VERSION@|$VERSION|g" \
+        "$template" > "$DOCS/$name"
+done
+
+# A plain, unmissable marker on the landing page. Inserted right after <body>
+# so it shows before anything else, whatever the template's structure.
+if [ -f "$DOCS/index.html" ]; then
+    banner='<p style="margin:0;padding:10px 16px;background:#8a5a00;color:#fff;font:600 14px system-ui;text-align:center">BETA channel — pre-release test builds. For the stable repo, use '"$MAIN_BASE"'/</p>'
+    awk -v b="$banner" '{print} /<body[^>]*>/ && !done {print b; done=1}' \
+        "$DOCS/index.html" > "$DOCS/index.html.tmp" && mv "$DOCS/index.html.tmp" "$DOCS/index.html"
+fi
+
+cd "$DOCS"
+: > Packages
+
+DEPSTAMP="$(cat depiction.json depiction.html 2>/dev/null | md5sum | cut -c1-8)"
+
+for deb in debs/*.deb; do
+    dpkg-deb -f "$deb" |
+        grep -v -E '^(Filename|Size|MD5sum|SHA1|SHA256|Depiction|SileoDepiction|Icon):' >> Packages
+    {
+        # Served from the beta channel itself, not a GitHub release: a beta is
+        # not tagged. The URL a tester added is .../beta/, so a relative
+        # Filename resolves under it.
+        echo "Filename: $deb"
+        echo "Size: $(stat -c%s "$deb")"
+        echo "MD5sum: $(md5sum "$deb" | cut -d' ' -f1)"
+        echo "SHA1: $(sha1sum "$deb" | cut -d' ' -f1)"
+        echo "SHA256: $(sha256sum "$deb" | cut -d' ' -f1)"
+        echo "Icon: $BASE_URL/CydiaIcon.png?v=$VERSION"
+        echo "Depiction: $BASE_URL/depiction.html?v=$VERSION-$DEPSTAMP"
+        echo "SileoDepiction: $BASE_URL/depiction.json?v=$VERSION-$DEPSTAMP"
+        echo "Homepage: $BASE_URL"
+        echo
+    } >> Packages
+done
+
+rm -f Packages.gz Packages.bz2
+gzip -9 -c -n Packages > Packages.gz
+command -v bzip2 >/dev/null && bzip2 -9 -c Packages > Packages.bz2 || true
+
+hash_line() { echo " $(sha256sum "$1" | cut -d' ' -f1) $(stat -c%s "$1") $1"; }
+md5_line()  { echo " $(md5sum "$1"    | cut -d' ' -f1) $(stat -c%s "$1") $1"; }
+
+{
+    echo "Origin: HotspotPro (beta)"
+    echo "Label: HotspotPro (beta)"
+    echo "Suite: beta"
+    echo "Version: 1.0"
+    echo "Codename: hotspotpro-beta"
+    echo "Architectures: iphoneos-arm iphoneos-arm64"
+    echo "Components: main"
+    echo "Description: HotspotPro pre-release test builds"
+    echo "MD5Sum:"
+    md5_line Packages
+    md5_line Packages.gz
+    [ -f Packages.bz2 ] && md5_line Packages.bz2
+    echo "SHA256:"
+    hash_line Packages
+    hash_line Packages.gz
+    [ -f Packages.bz2 ] && hash_line Packages.bz2
+} > Release
+
+echo "beta repo written to $DOCS for $BASE_URL"
+grep -E '^(Package|Version|Architecture|Filename): ' Packages | sed 's/^/  /'


### PR DESCRIPTION
A device that never left flickered between "connected" and "offline" for
as long as the Settings pane was open.

Presence turned on a single signal: whether the root daemon's BPF tap had
captured a frame from that MAC in the last 30 seconds. Nothing obliges an
associated client to put a frame on the air that often. A phone in a
pocket with its screen off goes minutes between an ARP for the gateway,
an mDNS announcement and a DHCP renewal, so its stamp aged past the
cutoff, the device dropped out of the connected list and reappeared under
the offline heading, and the next stray packet put it back.

Two smaller faults made it visible rather than merely wrong. The count in
the status row, the summary row on the stock pane and the refresh
signature each asked HPCopyConnectedDevices() directly, so the header
could say "1 device connected" over a row marked offline. And the tap's
own outage was indistinguishable from a client's silence: when the bridge
flaps the tap closes and every per-client stamp ages at once.

The rule now lives in one place, HPFilterPresentDevices(), and every
caller reaches it through HPCopyPresentDevices():

  * The window is four minutes, not thirty seconds. A device that has
    really left lingers for a few minutes longer; showing a present
    device as offline is the worse of the two errors.
  * Two more signals count as evidence of presence, either of which
    clears the window on its own: an ARP entry whose expiry the kernel
    pushed forward, and a DHCP lease end that moved. Both are compared
    against their own previous value, never against the clock, so neither
    assumes anything about what units the kernel keeps them in.
  * A device has to fail every test on three consecutive polls before it
    is dropped, the same hysteresis the hotspot status row already uses.
  * The daemon publishes when its current tap was opened, and no
    departure is inferred until that tap has been listening for the whole
    window it is being asked to interpret. Its heartbeat also ticks now
    when no client has sent a byte, which is what its own documented
    contract always claimed.
  * Answers are shared within a second, so the rows, the count above them
    and the refresh signature cannot disagree inside one tick.

The rule takes all of its inputs as arguments, so `hotspotpro selftest`
drives it without a hotspot, a daemon or a clock; the idle-client case
that caused this fails against the old rule. `hotspotpro dump` grows a
section showing the evidence behind the verdict, which is what to read
when a device that is plainly connected is reported as offline.