### PR TITLE
0.6.9: restore tip jar, lift iOS 18 install block

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ docs/      the generated APT repo, served by GitHub Pages
 
 ## Changelog
 
+**0.6.9**
+- Now installs and runs on iOS 18. The crash that made earlier builds unsafe
+  there was the arm64e linker marker fixed in 0.6.7, so the install block is
+  lifted. Still only tested through iOS 17 — reports from iOS 18 welcome.
+- The **Buy Me a Beer 🍺** tip row is back and always shown, linking to Ko-fi.
+
 **0.6.8**
 - Connected devices no longer flip between online and offline, or show
   "no devices" while a device is actually connected — presence is judged over a

--- a/control
+++ b/control
@@ -1,10 +1,10 @@
 Package: com.dangkhoa.hotspotpro
 Name: HotspotPro
-Version: 0.6.8
+Version: 0.6.9
 Architecture: iphoneos-arm64
 Description: See how much data your Personal Hotspot has shared, who is using it, and cap them.
 Maintainer: DangKhoa <dangkhoa116@gmail.com>
 Author: DangKhoa <dangkhoa116@gmail.com>
 Section: Networking
-Depends: mobilesubstrate (>= 0.9.5000), firmware (>= 14.0), firmware (<< 18.0)
+Depends: mobilesubstrate (>= 0.9.5000), firmware (>= 14.0)
 Tag: purpose::extension, role::enduser

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -510,15 +510,6 @@ int main(int argc, char *argv[]) {
         gInstalledBlocks = [NSMutableDictionary dictionary];
         HPDaemonLog(@"started, uid %d", getuid());
 
-        // Same gate as the tweak: iOS 18 is untested and reported unstable, and
-        // this process is root, taps packets and writes routes. Exit rather than
-        // run any of that against kernel structures nobody here has checked.
-        NSOperatingSystemVersion ios18 = { 18, 0, 0 };
-        if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:ios18]) {
-            HPDaemonLog(@"iOS 18+ — untested firmware, exiting without tapping");
-            HPWriteDaemonStatus(@"gated-ios18");
-            return 0;
-        }
         HPWriteDaemonStatus(@"starting");
 
         HPClearStaleBlocks();

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -22,15 +22,14 @@
 /// hotspot clients at a handful, but the historical list is unbounded.
 static const NSUInteger kHPMaxOfflineRows = 6;
 
-/// Tip jar. The link comes from `donate-url.txt`, which the build scripts turn
-/// into DonateURL.h, so changing it never means editing code. While it is empty
-/// the row is not shown at all — an unconfigured build never presents a button
-/// that goes nowhere.
+/// Tip jar. `donate-url.txt` → DonateURL.h (via the build scripts) overrides the
+/// link without editing code; with no override it falls back to the maintainer's
+/// public Ko-fi, so the row is always present.
 #if __has_include("DonateURL.h")
 #import "DonateURL.h"
 #endif
 #ifndef HP_DONATE_URL
-#define HP_DONATE_URL ""
+#define HP_DONATE_URL "https://ko-fi.com/dangkhoa116"
 #endif
 static NSString *const kHPDonateURL = @HP_DONATE_URL;
 
@@ -1377,21 +1376,9 @@ static void HPReloadValues(PSListController *pane) {
 
 #pragma mark - Entry
 
-// See SpringBoard.x for why iOS 18 is gated. Duplicated rather than shared
-// because the two dylibs no longer have a translation unit in common, and a
-// four-line check is cheaper than a header to hold it.
-static BOOL HPFirmwareUntested(void) {
-    NSOperatingSystemVersion ios18 = { 18, 0, 0 };
-    return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:ios18];
-}
-
 %ctor {
     @autoreleasepool {
         @try {
-            if (HPFirmwareUntested()) {
-                HPLog(@"iOS 18+ — settings hooks disabled, firmware untested");
-                return;
-            }
             %init(SettingsHooks);
             HPLog(@"settings hooks installed");
         } @catch (NSException *e) {

--- a/src/SpringBoard.x
+++ b/src/SpringBoard.x
@@ -194,27 +194,11 @@ static void HPStartCollector(void) {
 
 #pragma mark - Entry
 
-// iOS 18 is untested and reported broken: users on 18.3.1 and 18.4.1 got
-// resprings, safe mode, and a Settings app that refused to open. Working
-// reports exist for 15.4.1, 16.5, 16.7 and 17.0.2.
-//
-// The package also refuses to install on 18 (see the firmware dependency in
-// control); this gate is the second line, for anyone who force-installs or
-// upgrades across the boundary.
-static BOOL HPFirmwareUntested(void) {
-    NSOperatingSystemVersion ios18 = { 18, 0, 0 };
-    return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:ios18];
-}
-
 %ctor {
     @autoreleasepool {
         @try {
             // The filter plist already limits this dylib to SpringBoard, so the
             // bundle check is belt and braces rather than dispatch.
-            if (HPFirmwareUntested()) {
-                HPLog(@"iOS 18+ — collector disabled, firmware untested");
-                return;
-            }
             HPStartCollector();
         } @catch (NSException *e) {
             HPLog(@"ctor failed: %@", e);

--- a/web/depiction.json
+++ b/web/depiction.json
@@ -78,6 +78,11 @@
       "views": [
         {
           "class": "DepictionMarkdownView",
+          "markdown": "**0.6.9**\n• Now installs and runs on iOS 18 — the crash behind the old block was the arm64e marker fixed in 0.6.7\n• The Buy Me a Beer 🍺 tip row is back, always shown"
+        },
+        { "class": "DepictionSeparatorView" },
+        {
+          "class": "DepictionMarkdownView",
           "markdown": "**0.6.8**\n• Connected devices no longer flip between online and offline, or show \"no devices\" while actually connected\n• Rename a device — the new name shows right away\n• Per-device limits: a block can never get stuck, so a device is never left without internet after you lift its limit or turn tracking off\n• A device over its limit but not actually cut off now says so plainly"
         },
         { "class": "DepictionSeparatorView" },


### PR DESCRIPTION
Brings the 0.6.9 code onto master. PR #4 was merged but only carried the README-tightening commit — this commit (the iOS 18 unlock + tip-jar default + version bump) never reached master, so master is still `0.6.9`-less at `0.6.8`.

Already beta-tested: `0.6.9~beta1` was built from this exact change and confirmed working on device.

## Changes
- **Buy Me a Beer 🍺 always shown** — `HP_DONATE_URL` defaults to the maintainer's public Ko-fi, so the row no longer depends on a `DONATE_URL` build secret being present (a `DonateURL.h` still overrides it).
- **iOS 18 install block lifted** — removes the `firmware (<< 18.0)` ceiling in `control` and the runtime iOS-18 gates in the SpringBoard collector, the Settings hooks, and the daemon. The crash behind the block was the arm64e linker marker fixed in 0.6.7.
- **Version → 0.6.9** in `control`, with changelog entries in `README.md` and `web/depiction.json` (top entry matches `control`, so the repo-build guard passes).

## Notes
- `src/Settings.x` and `src/SpringBoard.x` kept CRLF; other files LF.
- No packaging/APT changes; `docs/` is regenerated by the release workflow.

Once merged, the stable 0.6.9 build + release can be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012zodxUWqczMwtRBfUDjVNW)_