### PR TITLE
0.7.0: per-device blocking, upload/download split, clearer device identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ docs/      the generated APT repo, served by GitHub Pages
 
 ## Changelog
 
+**0.7.0**
+- **Block a device from the hotspot.** Each device's page has a *Block from
+  Hotspot* switch: the root daemon installs a host reject route for that client,
+  so it can no longer reach the internet through your hotspot. It stays joined to
+  Wi-Fi (iOS exposes no way to force a client off the air), but nothing loads.
+  Turn it off to let it back on; blocks clear on reboot and on uninstall. A
+  device that rejoins with a fresh randomised Wi-Fi address is a new device and
+  is not still blocked. This reuses the same mechanism as the per-device limit.
+- **Upload and download, split out.** Every device's own page now shows
+  Downloaded, Uploaded and Total for the period, and the usage pane shows the
+  same split for the hotspot as a whole. The daemon's per-client tap counts each
+  direction separately; the totals are unchanged. For a data cap only the Total
+  matters — carriers bill both directions together — but the split shows what a
+  device is actually doing.
+- **Clearer device identity.** A device with no name of its own is labelled
+  "Private Address" (a randomised MAC) rather than shown as a bare MAC, and its
+  page now always lists both its IP and MAC address under an Identity section.
+
 **0.6.9**
 - Now installs and runs on iOS 18. The crash that made earlier builds unsafe
   there was the arm64e linker marker fixed in 0.6.7, so the install block is

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.dangkhoa.hotspotpro
 Name: HotspotPro
-Version: 0.6.9
+Version: 0.7.0
 Architecture: iphoneos-arm64
 Description: See how much data your Personal Hotspot has shared, who is using it, and cap them.
 Maintainer: DangKhoa <dangkhoa116@gmail.com>

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -194,6 +194,17 @@ uint64_t HPAccumulateDelta(NSMutableDictionary *last,
                            NSArray<NSString *> *names,
                            BOOL baselineOnly);
 
+/// As HPAccumulateDelta, but also reports the split. `*addedUp` receives the
+/// bytes the clients SENT (ap1 ibytes: client -> internet) and `*addedDown` the
+/// bytes they RECEIVED (ap1 obytes: internet -> client); the return value is
+/// their sum, identical to HPAccumulateDelta. Either out-pointer may be NULL.
+uint64_t HPAccumulateDeltaSplit(NSMutableDictionary *last,
+                                NSArray<NSDictionary *> *ifaces,
+                                NSArray<NSString *> *names,
+                                BOOL baselineOnly,
+                                uint64_t *addedUp,
+                                uint64_t *addedDown);
+
 #pragma mark - Connected devices
 
 // Keys for ARP entries / leases / joined devices.
@@ -269,6 +280,23 @@ NSArray<NSDictionary *> *HPFilterPresentDevices(NSArray<NSDictionary *> *arp,
 /// daemon last started, so callers must take deltas rather than read them as
 /// per-period figures.
 NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void);
+
+/// The same, split by direction: upload is what the client sent, download is
+/// what it received. Sum to the total above. Empty when the daemon predates the
+/// split (an older state file) or is not running.
+NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceUpload(void);
+NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceDownload(void);
+
+/// Whether a MAC is locally administered — the "private Wi-Fi address" bit iOS,
+/// Android and others set on a randomised MAC. Such an address carries no vendor
+/// and is not stable across reconnects, so it is worth labelling as such rather
+/// than showing as if it identified the hardware.
+BOOL HPMacIsPrivate(NSString *mac);
+
+/// A human label for a device given every name source, in priority order:
+/// a user-set nickname, then the name the device announced over DHCP, then
+/// "Private Address" for a randomised MAC, then a generic fallback. Never nil.
+NSString *HPDeviceDisplayName(NSString *mac, NSString *dhcpName, NSString *nickname);
 
 /// "4.72 GB", "812 MB" — for display.
 NSString *HPFormatBytes(uint64_t bytes);

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -287,11 +287,14 @@ uint64_t HPTotalBytes(NSArray<NSDictionary *> *ifaces, NSArray<NSString *> *name
 
 #pragma mark - Accumulation
 
-uint64_t HPAccumulateDelta(NSMutableDictionary *last,
-                           NSArray<NSDictionary *> *ifaces,
-                           NSArray<NSString *> *names,
-                           BOOL baselineOnly) {
-    uint64_t added = 0;
+uint64_t HPAccumulateDeltaSplit(NSMutableDictionary *last,
+                                NSArray<NSDictionary *> *ifaces,
+                                NSArray<NSString *> *names,
+                                BOOL baselineOnly,
+                                uint64_t *addedUp,
+                                uint64_t *addedDown) {
+    uint64_t up = 0;    // ap1 ibytes: client -> internet
+    uint64_t down = 0;  // ap1 obytes: internet -> client
 
     for (NSString *name in names) {
         NSDictionary *cur = HPInterfaceNamed(ifaces, name);
@@ -306,8 +309,8 @@ uint64_t HPAccumulateDelta(NSMutableDictionary *last,
             uint64_t po = [prev[HPLastOutBytesKey] unsignedLongLongValue];
             // A counter that went backwards means the interface was torn down
             // and recreated (hotspot toggled), so the new value is the delta.
-            added += (ci >= pi) ? (ci - pi) : ci;
-            added += (co >= po) ? (co - po) : co;
+            up   += (ci >= pi) ? (ci - pi) : ci;
+            down += (co >= po) ? (co - po) : co;
         }
         // First sight of an interface adds NOTHING; it is only baselined.
         //
@@ -323,7 +326,16 @@ uint64_t HPAccumulateDelta(NSMutableDictionary *last,
         last[name] = @{ HPLastInBytesKey : @(ci), HPLastOutBytesKey : @(co) };
     }
 
-    return added;
+    if (addedUp)   *addedUp = up;
+    if (addedDown) *addedDown = down;
+    return up + down;
+}
+
+uint64_t HPAccumulateDelta(NSMutableDictionary *last,
+                           NSArray<NSDictionary *> *ifaces,
+                           NSArray<NSString *> *names,
+                           BOOL baselineOnly) {
+    return HPAccumulateDeltaSplit(last, ifaces, names, baselineOnly, NULL, NULL);
 }
 
 #pragma mark - ARP
@@ -736,6 +748,20 @@ NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
+NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceUpload(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *bytes = file[@"uploadByMac"];
+    return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
+}
+
+NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceDownload(void) {
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
+                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *bytes = file[@"downloadByMac"];
+    return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
+}
+
 NSDictionary *HPCopyDaemonStatus(void) {
     NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
                               @"/var/mobile/Library/Caches/hotspotpro-daemon.plist"];
@@ -777,6 +803,26 @@ NSDictionary<NSString *, NSDate *> *HPCopyDaemonLastSeen(void) {
 }
 
 #pragma mark - Helpers
+
+BOOL HPMacIsPrivate(NSString *mac) {
+    // The second-least-significant bit of the first octet is the "locally
+    // administered" bit; a randomised (private) MAC sets it. 172.20.10.x clients
+    // that turned it on show up here, and their address tells us nothing about
+    // the hardware and changes on every reconnect.
+    if (mac.length < 2) return NO;
+    unsigned int first = 0;
+    [[NSScanner scannerWithString:[mac substringToIndex:2]] scanHexInt:&first];
+    return (first & 0x02) != 0;
+}
+
+NSString *HPDeviceDisplayName(NSString *mac, NSString *dhcpName, NSString *nickname) {
+    if (nickname.length) return nickname;
+    // The DHCP name is what the device calls itself ("Johns-iPhone"); prefer it,
+    // but never when it is just the MAC echoed back, which reads as no name.
+    if (dhcpName.length && ![dhcpName isEqualToString:mac]) return dhcpName;
+    if (HPMacIsPrivate(mac)) return @"Private Address";
+    return @"Device";
+}
 
 NSString *HPFormatBytes(uint64_t bytes) {
     double b = (double)bytes;

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -71,6 +71,12 @@ static const NSTimeInterval kFlushInterval = 10.0;
 #pragma mark - State
 
 static NSMutableDictionary<NSString *, NSNumber *> *gBytesByMac;
+// The same totals split by direction. Upload is what the client SENT (a frame
+// whose source is the client); download is what it RECEIVED. They sum to
+// gBytesByMac, which is kept as-is so the per-device limit logic and older
+// readers are untouched.
+static NSMutableDictionary<NSString *, NSNumber *> *gUploadByMac;
+static NSMutableDictionary<NSString *, NSNumber *> *gDownloadByMac;
 static NSMutableDictionary<NSString *, NSDate *> *gLastSeenByMac;
 static NSMutableSet<NSString *> *gTouchedMacs;
 // When the tap now open was opened, or nil while there is none. Published so
@@ -141,6 +147,8 @@ static void HPPruneDevices(void) {
     }
     for (NSString *mac in expired) {
         [gBytesByMac removeObjectForKey:mac];
+        [gUploadByMac removeObjectForKey:mac];
+        [gDownloadByMac removeObjectForKey:mac];
         [gLastSeenByMac removeObjectForKey:mac];
     }
 
@@ -158,6 +166,8 @@ static void HPPruneDevices(void) {
     NSUInteger excess = gBytesByMac.count - kMaxDevices;
     for (NSUInteger i = 0; i < excess && i < byAge.count; i++) {
         [gBytesByMac removeObjectForKey:byAge[i]];
+        [gUploadByMac removeObjectForKey:byAge[i]];
+        [gDownloadByMac removeObjectForKey:byAge[i]];
         [gLastSeenByMac removeObjectForKey:byAge[i]];
     }
     HPDaemonLog(@"capped device table to %lu entries", (unsigned long)gBytesByMac.count);
@@ -176,6 +186,8 @@ static void HPFlushCounters(void) {
         NSString *tmp = [gDevicesPath stringByAppendingPathExtension:@"tmp"];
         NSMutableDictionary *payload = [@{
             @"bytesByMac"   : gBytesByMac,
+            @"uploadByMac"  : gUploadByMac,
+            @"downloadByMac": gDownloadByMac,
             @"lastSeenByMac": gLastSeenByMac,
             @"updated"      : [NSDate date],
         } mutableCopy];
@@ -485,6 +497,11 @@ static void HPConsume(const char *buf, ssize_t len, NSString *bridgeMac) {
                 if (fromClient || !isArp) {
                     uint64_t prev = [gBytesByMac[client] unsignedLongLongValue];
                     gBytesByMac[client] = @(prev + bh->bh_datalen);
+                    // A frame the client sent is its upload; one sent toward it
+                    // is its download. The two sum back to gBytesByMac.
+                    NSMutableDictionary *dir = fromClient ? gUploadByMac : gDownloadByMac;
+                    uint64_t prevDir = [dir[client] unsignedLongLongValue];
+                    dir[client] = @(prevDir + bh->bh_datalen);
                 }
                 // Bytes are counted in both directions; presence is not. Only a
                 // frame the client SENT is evidence that it is here — a frame
@@ -505,6 +522,8 @@ static void HPConsume(const char *buf, ssize_t len, NSString *bridgeMac) {
 int main(int argc, char *argv[]) {
     @autoreleasepool {
         gBytesByMac = [NSMutableDictionary dictionary];
+        gUploadByMac = [NSMutableDictionary dictionary];
+        gDownloadByMac = [NSMutableDictionary dictionary];
         gLastSeenByMac = [NSMutableDictionary dictionary];
         gTouchedMacs = [NSMutableSet set];
         gInstalledBlocks = [NSMutableDictionary dictionary];
@@ -524,6 +543,14 @@ int main(int argc, char *argv[]) {
         NSDictionary *existing = [NSDictionary dictionaryWithContentsOfFile:gDevicesPath];
         if ([existing[@"bytesByMac"] isKindOfClass:[NSDictionary class]]) {
             [gBytesByMac addEntriesFromDictionary:existing[@"bytesByMac"]];
+            // Directional counters were added in 0.7.0; an older file has none,
+            // in which case they simply start fresh and re-accumulate.
+            if ([existing[@"uploadByMac"] isKindOfClass:[NSDictionary class]]) {
+                [gUploadByMac addEntriesFromDictionary:existing[@"uploadByMac"]];
+            }
+            if ([existing[@"downloadByMac"] isKindOfClass:[NSDictionary class]]) {
+                [gDownloadByMac addEntriesFromDictionary:existing[@"downloadByMac"]];
+            }
             if ([existing[@"lastSeenByMac"] isKindOfClass:[NSDictionary class]]) {
                 [gLastSeenByMac addEntriesFromDictionary:existing[@"lastSeenByMac"]];
             }

--- a/src/Prefs.h
+++ b/src/Prefs.h
@@ -24,6 +24,7 @@ extern NSString *const HPCfgResetDayKey;    // int 1-31, default 1
 extern NSString *const HPCfgWarnPercentKey; // int,    default 80
 extern NSString *const HPCfgNicknamesKey;   // dict mac -> user-set name
 extern NSString *const HPCfgDeviceLimitsKey;// dict mac -> GB (double), per device
+extern NSString *const HPCfgManualBlocksKey;// dict mac -> BOOL, cut off by hand
 
 /// Devices the collector has decided are over their own limit, written for the
 /// root daemon to enforce. The daemon is the only thing that can install a
@@ -49,11 +50,15 @@ void HPPostTickRequest(void);
 #pragma mark - State
 
 extern NSString *const HPStTotalBytesKey;   // unsigned long long, this period
+extern NSString *const HPStUploadBytesKey;   // unsigned long long, client -> internet
+extern NSString *const HPStDownloadBytesKey; // unsigned long long, internet -> client
 extern NSString *const HPStPeriodStartKey;  // NSDate
 extern NSString *const HPStNextResetKey;    // NSDate
 extern NSString *const HPStLastRawKey;      // dict ifname -> {i, o}
 extern NSString *const HPStBaselinedKey;    // BOOL, first run has happened
 extern NSString *const HPStLastDevRawKey;   // dict mac -> cumulative daemon bytes
+extern NSString *const HPStLastDevRawUpKey;  // dict mac -> cumulative daemon upload
+extern NSString *const HPStLastDevRawDownKey;// dict mac -> cumulative daemon download
 extern NSString *const HPStDevBaselinedKey; // BOOL, daemon counters baselined
 extern NSString *const HPStWarnFiredKey;    // BOOL, warning shown this period
 extern NSString *const HPStLimitFiredKey;   // BOOL, limit alert shown this period

--- a/src/Prefs.m
+++ b/src/Prefs.m
@@ -7,6 +7,7 @@ NSString *const HPCfgResetDayKey    = @"resetDay";
 NSString *const HPCfgWarnPercentKey = @"warnPercent";
 NSString *const HPCfgNicknamesKey    = @"nicknames";
 NSString *const HPCfgDeviceLimitsKey = @"deviceLimits";
+NSString *const HPCfgManualBlocksKey = @"manualBlocks";
 
 NSString *const HPPrefsChangedNotification = @"com.dangkhoa.hotspotpro/prefschanged";
 const char *const HPTickRequestNotification = "com.dangkhoa.hotspotpro/tick";
@@ -16,11 +17,15 @@ void HPPostTickRequest(void) {
 }
 
 NSString *const HPStTotalBytesKey   = @"totalBytes";
+NSString *const HPStUploadBytesKey   = @"uploadBytes";   // client -> internet (ap1 ibytes)
+NSString *const HPStDownloadBytesKey = @"downloadBytes"; // internet -> client (ap1 obytes)
 NSString *const HPStPeriodStartKey  = @"periodStart";
 NSString *const HPStNextResetKey    = @"nextReset";
 NSString *const HPStLastRawKey      = @"lastRaw";
 NSString *const HPStBaselinedKey    = @"baselined";
 NSString *const HPStLastDevRawKey   = @"lastDevRaw";
+NSString *const HPStLastDevRawUpKey  = @"lastDevRawUp";   // per-mac upload baseline
+NSString *const HPStLastDevRawDownKey = @"lastDevRawDown"; // per-mac download baseline
 NSString *const HPStDevBaselinedKey = @"devBaselined";
 NSString *const HPStWarnFiredKey    = @"warnFired";
 NSString *const HPStLimitFiredKey   = @"limitFired";
@@ -61,6 +66,7 @@ NSDictionary *HPConfig(void) {
         HPCfgWarnPercentKey : @80,
         HPCfgNicknamesKey    : @{},
         HPCfgDeviceLimitsKey : @{},
+        HPCfgManualBlocksKey : @{},
     } mutableCopy];
     if ([onDisk isKindOfClass:[NSDictionary class]]) [cfg addEntriesFromDictionary:onDisk];
 

--- a/src/Settings.x
+++ b/src/Settings.x
@@ -107,6 +107,16 @@ static HPSettingsHelper *gHelper;
     return HPFormatBytes([state[HPStTotalBytesKey] unsignedLongLongValue]);
 }
 
+- (id)downloadedValue:(PSSpecifier *)spec {
+    NSDictionary *state = HPStateLoad();
+    return HPFormatBytes([state[HPStDownloadBytesKey] unsignedLongLongValue]);
+}
+
+- (id)uploadedValue:(PSSpecifier *)spec {
+    NSDictionary *state = HPStateLoad();
+    return HPFormatBytes([state[HPStUploadBytesKey] unsignedLongLongValue]);
+}
+
 - (id)remainingValue:(PSSpecifier *)spec {
     NSDictionary *state = HPStateLoad();
     double limitGB = [HPConfig()[HPCfgLimitGBKey] doubleValue];
@@ -212,10 +222,18 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSString *mac = [spec propertyForKey:@"hpMac"];
     if (!mac.length) return ip;
 
-    NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
+    NSDictionary *state = HPStateLoad();
+    NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};
     uint64_t bytes = [seen[mac][@"bytes"] unsignedLongLongValue];
-    if (bytes == 0) return ip;
-    return [NSString stringWithFormat:@"%@ · %@", HPFormatBytes(bytes), ip];
+    NSString *base = (bytes == 0) ? ip
+                                  : [NSString stringWithFormat:@"%@ · %@",
+                                              HPFormatBytes(bytes), ip];
+    // A blocked device says so right in the list, so it need not be opened to
+    // confirm the cut-off is in place.
+    if ([(state[HPStBlockedMacsKey] ?: @[]) containsObject:mac]) {
+        return [base stringByAppendingString:@" · blocked"];
+    }
+    return base;
 }
 
 - (id)seenValue:(PSSpecifier *)spec {
@@ -345,8 +363,7 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     if (![nicknames isKindOfClass:[NSDictionary class]]) nicknames = @{};
     for (NSDictionary *d in HPLiveConnectedDevices()) {
         NSString *mac = d[HPDevMacKey] ?: @"";
-        NSString *shown = [nicknames[mac] length] ? nicknames[mac]
-                                                  : (d[HPDevNameKey] ?: @"");
+        NSString *shown = HPDeviceDisplayName(mac, d[HPDevNameKey], nicknames[mac]);
         [sig appendFormat:@"%@=%@,", mac, shown];
     }
     [sig appendString:@"|"];
@@ -356,8 +373,7 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSDictionary *seen = state[HPStDevicesSeenKey] ?: @{};
     for (NSString *mac in [seen.allKeys sortedArrayUsingSelector:@selector(compare:)]) {
         if ([seen[mac][@"bytes"] unsignedLongLongValue] == 0) continue;
-        NSString *shown = [nicknames[mac] length] ? nicknames[mac]
-                                                  : (seen[mac][@"name"] ?: mac);
+        NSString *shown = HPDeviceDisplayName(mac, seen[mac][@"name"], nicknames[mac]);
         [sig appendFormat:@"%@=%@,", mac, shown];
     }
     return sig;
@@ -369,6 +385,10 @@ static BOOL HPHotspotIsActiveSmoothed(NSArray<NSDictionary *> *ifaces) {
     NSDictionary *state = HPStateLoad();
     NSMutableString *sig = [NSMutableString string];
     [sig appendFormat:@"%@|%@|", state[HPStTotalBytesKey], state[HPStIfNamesKey]];
+    // Blocking a device changes no byte total, so its row would not otherwise
+    // refresh to show (or drop) the "blocked" marker.
+    [sig appendFormat:@"b:%@|",
+                      [(state[HPStBlockedMacsKey] ?: @[]) componentsJoinedByString:@","]];
 
     // The status row is computed live, so its inputs belong in the signature —
     // otherwise switching the hotspot on would not refresh the row until some
@@ -537,6 +557,8 @@ static NSArray *HPBuildBodySpecifiers(void) {
     // --- usage ------------------------------------------------------------
     [specs addObject:HPGroup(@"THIS PERIOD", nil)];
     [specs addObject:HPValueRow(@"Used", @selector(usedValue:))];
+    [specs addObject:HPValueRow(@"Downloaded", @selector(downloadedValue:))];
+    [specs addObject:HPValueRow(@"Uploaded", @selector(uploadedValue:))];
     [specs addObject:HPValueRow(@"Remaining", @selector(remainingValue:))];
     [specs addObject:HPValueRow(@"Resets On", @selector(resetsValue:))];
     [specs addObject:HPValueRow(@"Hotspot", @selector(statusValue:))];
@@ -652,7 +674,8 @@ static NSArray *HPBuildBodySpecifiers(void) {
     // The nickname is baked into device rows and the "seen this period" record
     // by the collector, so a tick rebuilds them under the new name; do it now
     // rather than waiting for the next sample.
-    self.title = name.length ? name : [self hpMac];
+    NSString *dhcp = HPStateLoad()[HPStDevicesSeenKey][[self hpMac]][@"name"];
+    self.title = HPDeviceDisplayName([self hpMac], dhcp, name.length ? name : nil);
     HPPostTickRequest();
 }
 
@@ -682,20 +705,61 @@ static NSArray *HPBuildBodySpecifiers(void) {
     return HPFormatBytes([seen[[self hpMac]][@"bytes"] unsignedLongLongValue]);
 }
 
+- (id)hpDownValue:(PSSpecifier *)spec {
+    NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
+    return HPFormatBytes([seen[[self hpMac]][@"down"] unsignedLongLongValue]);
+}
+
+- (id)hpUpValue:(PSSpecifier *)spec {
+    NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
+    return HPFormatBytes([seen[[self hpMac]][@"up"] unsignedLongLongValue]);
+}
+
+- (id)hpMacValue:(PSSpecifier *)spec {
+    return [self hpMac];
+}
+
+- (id)hpBlockedValue:(PSSpecifier *)spec {
+    NSDictionary *blocks = HPConfig()[HPCfgManualBlocksKey];
+    BOOL on = [blocks isKindOfClass:[NSDictionary class]] &&
+              [blocks[[self hpMac]] boolValue];
+    return @(on);
+}
+
+- (void)setHpBlocked:(id)value specifier:(PSSpecifier *)spec {
+    NSMutableDictionary *cfg =
+        [([NSDictionary dictionaryWithContentsOfFile:HPConfigPath()] ?: @{}) mutableCopy];
+    NSMutableDictionary *blocks = [(cfg[HPCfgManualBlocksKey] ?: @{}) mutableCopy];
+
+    if ([value boolValue]) blocks[[self hpMac]] = @YES;
+    else                   [blocks removeObjectForKey:[self hpMac]];   // let it back on
+
+    cfg[HPCfgManualBlocksKey] = blocks;
+    [cfg writeToFile:HPConfigPath() atomically:YES];
+
+    // The daemon is the only thing that can install the reject route, and it
+    // reads the blocklist the collector writes — so wake a tick now rather than
+    // waiting up to 10s, and the cut-off (or release) takes effect at once.
+    HPPostTickRequest();
+}
+
 - (id)hpStatusValue:(PSSpecifier *)spec {
     NSString *mac = [self hpMac];
     BOOL wantBlocked = [(HPStateLoad()[HPStBlockedMacsKey] ?: @[]) containsObject:mac];
+    BOOL manual = [HPConfig()[HPCfgManualBlocksKey][mac] boolValue];
 
     if (wantBlocked) {
         // "Blocked" is a claim about the routing table, and only the daemon
         // touches that. Say it is blocked only when the daemon confirms the
         // route is in and its heartbeat is recent; otherwise be honest that the
-        // device is over its limit but still has a working connection, which is
-        // what a dead or route-less daemon leaves behind.
+        // device still has a working connection, which is what a dead or
+        // route-less daemon leaves behind.
         BOOL enforced = [HPDaemonBlockedMacs() containsObject:mac];
         NSDate *flush = HPDaemonLastFlush();
         BOOL daemonAlive = flush && [[NSDate date] timeIntervalSinceDate:flush] <= 60.0;
-        if (enforced && daemonAlive) return @"Blocked — over its limit";
+        if (enforced && daemonAlive) {
+            return manual ? @"Blocked — cut off by you" : @"Blocked — over its limit";
+        }
         // Not actually cut off. Name why, from the daemon's own breadcrumb, so
         // this is a lead rather than a dead end.
         NSString *state = HPCopyDaemonStatus()[@"state"];
@@ -703,11 +767,12 @@ static NSArray *HPBuildBodySpecifiers(void) {
         if ([state isEqualToString:@"gated-ios18"])   why = @"unsupported on iOS 18";
         else if ([state isEqualToString:@"tracking-off"]) why = @"tracking is off";
         else if ([state isEqualToString:@"no-bpf"])   why = @"helper can't capture";
-        return [NSString stringWithFormat:@"Over limit — not enforced (%@)", why];
+        return [NSString stringWithFormat:@"%@ — not enforced (%@)",
+                manual ? @"Blocked" : @"Over limit", why];
     }
 
     double limit = [HPConfig()[HPCfgDeviceLimitsKey][mac] doubleValue];
-    return limit > 0 ? @"Allowed" : @"No limit set";
+    return limit > 0 ? @"Allowed" : @"Not blocked";
 }
 
 - (id)hpAddressValue:(PSSpecifier *)spec {
@@ -747,17 +812,27 @@ static NSArray *HPBuildBodySpecifiers(void) {
     [specs addObject:name];
 
     [specs addObject:HPGroup(@"THIS PERIOD", nil)];
-    PSSpecifier *used = [PSSpecifier preferenceSpecifierNamed:@"Used"
-                                                       target:self
-                                                          set:NULL
-                                                          get:@selector(hpUsedValue:)
-                                                       detail:nil
-                                                         cell:PSTitleValueCell
-                                                         edit:nil];
-    [used setProperty:@NO forKey:@"enabled"];
-    [specs addObject:used];
+    // Downloaded (what the device received) and Uploaded (what it sent) sum to
+    // Total. For a data cap only the Total matters — carriers bill both
+    // directions together — but the split shows at a glance what a device is
+    // actually doing.
+    NSArray<NSString *> *usageTitles = @[ @"Total", @"Downloaded", @"Uploaded" ];
+    SEL usageGetters[] = { @selector(hpUsedValue:), @selector(hpDownValue:),
+                           @selector(hpUpValue:) };
+    for (NSUInteger i = 0; i < usageTitles.count; i++) {
+        PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:usageTitles[i]
+                                                          target:self
+                                                             set:NULL
+                                                             get:usageGetters[i]
+                                                          detail:nil
+                                                            cell:PSTitleValueCell
+                                                            edit:nil];
+        [row setProperty:@NO forKey:@"enabled"];
+        [specs addObject:row];
+    }
 
-    PSSpecifier *address = [PSSpecifier preferenceSpecifierNamed:@"Address"
+    [specs addObject:HPGroup(@"IDENTITY", nil)];
+    PSSpecifier *address = [PSSpecifier preferenceSpecifierNamed:@"IP Address"
                                                           target:self
                                                              set:NULL
                                                              get:@selector(hpAddressValue:)
@@ -767,6 +842,19 @@ static NSArray *HPBuildBodySpecifiers(void) {
     [address setProperty:@NO forKey:@"enabled"];
     [specs addObject:address];
 
+    // Always shown: for a device with no name of its own, the MAC is the only
+    // thing that identifies it — and it is what a router's own client list shows.
+    PSSpecifier *mac = [PSSpecifier preferenceSpecifierNamed:@"MAC Address"
+                                                      target:self
+                                                         set:NULL
+                                                         get:@selector(hpMacValue:)
+                                                      detail:nil
+                                                        cell:PSTitleValueCell
+                                                        edit:nil];
+    [mac setProperty:@NO forKey:@"enabled"];
+    [specs addObject:mac];
+
+    [specs addObject:HPGroup(@"STATUS", nil)];
     PSSpecifier *status = [PSSpecifier preferenceSpecifierNamed:@"Status"
                                                          target:self
                                                             set:NULL
@@ -776,6 +864,21 @@ static NSArray *HPBuildBodySpecifiers(void) {
                                                            edit:nil];
     [status setProperty:@NO forKey:@"enabled"];
     [specs addObject:status];
+
+    [specs addObject:HPGroup(@"ACCESS",
+                             @"Blocking cuts this device off from the internet "
+                              "through your hotspot. It stays joined to Wi-Fi, but "
+                              "nothing loads. Turn it off to let it back on. A "
+                              "device that rejoins with a new random Wi-Fi address "
+                              "is a different device and is not still blocked.")];
+    PSSpecifier *block = [PSSpecifier preferenceSpecifierNamed:@"Block from Hotspot"
+                                                        target:self
+                                                           set:@selector(setHpBlocked:specifier:)
+                                                           get:@selector(hpBlockedValue:)
+                                                        detail:nil
+                                                          cell:PSSwitchCell
+                                                          edit:nil];
+    [specs addObject:block];
 
     [specs addObject:HPGroup(@"DEVICE LIMIT",
                              @"When this device passes its limit, the hotspot stops "
@@ -834,7 +937,7 @@ static NSArray *HPBuildBodySpecifiers(void) {
         NSString *nick = [nicknames isKindOfClass:[NSDictionary class]]
                              ? nicknames[[self hpMac]] : nil;
         NSDictionary *seen = HPStateLoad()[HPStDevicesSeenKey] ?: @{};
-        self.title = nick.length ? nick : (seen[[self hpMac]][@"name"] ?: [self hpMac]);
+        self.title = HPDeviceDisplayName([self hpMac], seen[[self hpMac]][@"name"], nick);
     } @catch (NSException *e) {}
 }
 
@@ -858,7 +961,7 @@ static NSArray *HPBuildDeviceRows(void) {
 
     for (NSDictionary *dev in devices) {
         NSString *nick = nicknames[dev[HPDevMacKey]];
-        NSString *shown = nick.length ? nick : (dev[HPDevNameKey] ?: @"Device");
+        NSString *shown = HPDeviceDisplayName(dev[HPDevMacKey], dev[HPDevNameKey], nick);
         // Built with a getter like every other value row, rather than a static
         // "value" property, which a PSTitleValueCell does not reliably display.
         PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:shown
@@ -902,7 +1005,7 @@ static NSArray *HPBuildDeviceRows(void) {
     for (NSString *mac in offline) {
         NSDictionary *record = seen[mac];
         NSString *nick = nicknames[mac];
-        NSString *shown = nick.length ? nick : (record[@"name"] ?: mac);
+        NSString *shown = HPDeviceDisplayName(mac, record[@"name"], nick);
 
         PSSpecifier *row = [PSSpecifier preferenceSpecifierNamed:shown
                                                           target:helper

--- a/src/Tracker.m
+++ b/src/Tracker.m
@@ -30,6 +30,8 @@ static void HPBeginNewPeriod(NSMutableDictionary *state, NSDate *now, NSInteger 
     }
 
     state[HPStTotalBytesKey]  = @0;
+    state[HPStUploadBytesKey]   = @0;
+    state[HPStDownloadBytesKey] = @0;
     state[HPStPeriodStartKey] = now;
     state[HPStNextResetKey]   = HPNextResetDate(now, resetDay);
     state[HPStWarnFiredKey]   = @NO;
@@ -100,7 +102,9 @@ NSDictionary *HPTick(void) {
     NSMutableDictionary *lastRaw = [(state[HPStLastRawKey] ?: @{}) mutableCopy];
     BOOL baselined = [state[HPStBaselinedKey] boolValue];
 
-    uint64_t added = HPAccumulateDelta(lastRaw, ifaces, names, !baselined);
+    uint64_t addedUp = 0, addedDown = 0;
+    uint64_t added = HPAccumulateDeltaSplit(lastRaw, ifaces, names, !baselined,
+                                            &addedUp, &addedDown);
     if (!baselined) {
         // First run ever: record where the counters stand without importing a
         // session that may predate this billing period.
@@ -110,6 +114,10 @@ NSDictionary *HPTick(void) {
 
     uint64_t total = [state[HPStTotalBytesKey] unsignedLongLongValue] + added;
     state[HPStTotalBytesKey] = @(total);
+    state[HPStUploadBytesKey]   =
+        @([state[HPStUploadBytesKey] unsignedLongLongValue] + addedUp);
+    state[HPStDownloadBytesKey] =
+        @([state[HPStDownloadBytesKey] unsignedLongLongValue] + addedDown);
     state[HPStLastRawKey]    = lastRaw;
     state[HPStIfNamesKey]    = names;
 
@@ -133,11 +141,11 @@ NSDictionary *HPTick(void) {
         NSString *mac = dev[HPDevMacKey];
         NSMutableDictionary *entry = [dev mutableCopy];
 
-        // A nickname the user set wins over the DHCP name, which for a client
-        // with a randomised MAC is often missing entirely.
+        // A nickname the user set wins over the DHCP name; a randomised MAC with
+        // no name of its own is labelled "Private Address" rather than shown as
+        // the raw MAC, which read as no name at all.
         NSString *nick = [nicknames isKindOfClass:[NSDictionary class]] ? nicknames[mac] : nil;
-        if (nick.length) entry[HPDevNameKey] = nick;
-        if (!entry[HPDevNameKey]) entry[HPDevNameKey] = mac;
+        entry[HPDevNameKey] = HPDeviceDisplayName(mac, dev[HPDevNameKey], nick);
         if ([presentMacs containsObject:mac]) [devicesNow addObject:entry];
 
         NSMutableDictionary *record = [(seen[mac] ?: @{}) mutableCopy];
@@ -153,29 +161,57 @@ NSDictionary *HPTick(void) {
     // folded in as deltas, exactly like the interface counters: a value that
     // dropped means the daemon restarted and the current figure is the delta.
     NSDictionary<NSString *, NSNumber *> *daemonBytes = HPCopyDaemonDeviceBytes();
-    NSMutableDictionary *lastDevRaw = [(state[HPStLastDevRawKey] ?: @{}) mutableCopy];
+    NSDictionary<NSString *, NSNumber *> *daemonUp    = HPCopyDaemonDeviceUpload();
+    NSDictionary<NSString *, NSNumber *> *daemonDown  = HPCopyDaemonDeviceDownload();
+    NSMutableDictionary *lastDevRaw     = [(state[HPStLastDevRawKey] ?: @{}) mutableCopy];
+    NSMutableDictionary *lastDevRawUp   = [(state[HPStLastDevRawUpKey] ?: @{}) mutableCopy];
+    NSMutableDictionary *lastDevRawDown = [(state[HPStLastDevRawDownKey] ?: @{}) mutableCopy];
     BOOL devBaselined = [state[HPStDevBaselinedKey] boolValue];
 
-    for (NSString *mac in daemonBytes) {
-        uint64_t cur = [daemonBytes[mac] unsignedLongLongValue];
-        uint64_t prev = [lastDevRaw[mac] unsignedLongLongValue];
-        uint64_t delta = 0;
-
-        if (lastDevRaw[mac] && devBaselined) {
-            delta = (cur >= prev) ? (cur - prev) : cur;
-        } else if (!lastDevRaw[mac] && devBaselined) {
-            // A device the daemon started counting after our last sample: all
-            // of its bytes belong to this period.
-            delta = cur;
+    // Delta of one cumulative daemon counter against its own stored baseline.
+    // `newOK` says whether a first sight with no baseline counts in full — true
+    // for a device the daemon began counting after our last sample, false for
+    // the first tick after the directional counters were added, where importing
+    // the whole running figure would double-count a period already tracked by
+    // the total.
+    uint64_t (^devDelta)(NSDictionary *, NSMutableDictionary *, NSString *, BOOL) =
+        ^uint64_t(NSDictionary *cumulative, NSMutableDictionary *baseline,
+                  NSString *mac, BOOL newOK) {
+        uint64_t cur = [cumulative[mac] unsignedLongLongValue];
+        uint64_t out = 0;
+        if (baseline[mac] && devBaselined) {
+            uint64_t prev = [baseline[mac] unsignedLongLongValue];
+            // A value that dropped means the daemon restarted; the figure is the
+            // delta.
+            out = (cur >= prev) ? (cur - prev) : cur;
+        } else if (!baseline[mac] && devBaselined && newOK) {
+            out = cur;
         }
-        lastDevRaw[mac] = @(cur);
+        baseline[mac] = @(cur);
+        return out;
+    };
 
-        if (delta == 0) continue;
+    for (NSString *mac in daemonBytes) {
+        // Captured before devDelta records this tick's baseline: a device with
+        // no total baseline yet is genuinely new, so its directional figures are
+        // all new too.
+        BOOL isNewDevice = (lastDevRaw[mac] == nil);
+
+        uint64_t delta     = devDelta(daemonBytes, lastDevRaw,     mac, isNewDevice);
+        uint64_t deltaUp   = devDelta(daemonUp,    lastDevRawUp,   mac, isNewDevice);
+        uint64_t deltaDown = devDelta(daemonDown,  lastDevRawDown, mac, isNewDevice);
+
+        if (delta == 0 && deltaUp == 0 && deltaDown == 0) continue;
         NSMutableDictionary *record = [(seen[mac] ?: @{}) mutableCopy];
         if (!record[@"first"]) record[@"first"] = now;
         record[@"last"] = now;
         record[@"bytes"] = @([record[@"bytes"] unsignedLongLongValue] + delta);
-        if (!record[@"name"]) record[@"name"] = mac;
+        record[@"up"]    = @([record[@"up"]    unsignedLongLongValue] + deltaUp);
+        record[@"down"]  = @([record[@"down"]  unsignedLongLongValue] + deltaDown);
+        if (!record[@"name"]) {
+            NSString *nick = [nicknames isKindOfClass:[NSDictionary class]] ? nicknames[mac] : nil;
+            record[@"name"] = HPDeviceDisplayName(mac, nil, nick);
+        }
         seen[mac] = record;
     }
 
@@ -184,10 +220,16 @@ NSDictionary *HPTick(void) {
     // longer reports are removed — pruning one it still counts would make its
     // whole running total look like new traffic on the next sample.
     for (NSString *mac in [lastDevRaw.allKeys copy]) {
-        if (!daemonBytes[mac]) [lastDevRaw removeObjectForKey:mac];
+        if (!daemonBytes[mac]) {
+            [lastDevRaw removeObjectForKey:mac];
+            [lastDevRawUp removeObjectForKey:mac];
+            [lastDevRawDown removeObjectForKey:mac];
+        }
     }
 
-    state[HPStLastDevRawKey]  = lastDevRaw;
+    state[HPStLastDevRawKey]     = lastDevRaw;
+    state[HPStLastDevRawUpKey]   = lastDevRawUp;
+    state[HPStLastDevRawDownKey] = lastDevRawDown;
     state[HPStDevBaselinedKey] = @YES;
 
     // Carry each connected device's period total onto its row.
@@ -206,25 +248,42 @@ NSDictionary *HPTick(void) {
     // A device drops off the list the moment it is under its cap again — which
     // is what unblocks it after a reset or a raised limit, with no extra state.
     NSDictionary *deviceLimits = cfg[HPCfgDeviceLimitsKey];
+    NSDictionary *manualBlocks = cfg[HPCfgManualBlocksKey];
     NSMutableArray *blocked = [NSMutableArray array];
     NSMutableArray *newlyBlocked = [NSMutableArray array];
     NSArray *previouslyBlocked = state[HPStBlockedMacsKey] ?: @[];
+
+    // Two independent reasons a device is cut off: it went over its own data
+    // limit, or the user blocked it by hand from its page. They feed the same
+    // reject-route mechanism, but only a limit block raises a popup — a manual
+    // block was the user's own doing and needs no announcing.
+    NSMutableSet<NSString *> *macsToBlock = [NSMutableSet set];
+    NSMutableSet<NSString *> *limitBlocked = [NSMutableSet set];
 
     if ([deviceLimits isKindOfClass:[NSDictionary class]]) {
         for (NSString *mac in deviceLimits) {
             double limitGB = [deviceLimits[mac] doubleValue];
             if (limitGB <= 0) continue;
-
             uint64_t used = [seen[mac][@"bytes"] unsignedLongLongValue];
             if (used < (uint64_t)(limitGB * 1024.0 * 1024.0 * 1024.0)) continue;
+            [macsToBlock addObject:mac];
+            [limitBlocked addObject:mac];
+        }
+    }
+    if ([manualBlocks isKindOfClass:[NSDictionary class]]) {
+        for (NSString *mac in manualBlocks) {
+            if ([manualBlocks[mac] boolValue]) [macsToBlock addObject:mac];
+        }
+    }
 
-            NSString *ip = seen[mac][@"ip"];
-            if (!ip) continue;   // nothing to install a route for
-            [blocked addObject:@{ @"mac" : mac, @"ip" : ip }];
+    for (NSString *mac in macsToBlock) {
+        NSString *ip = seen[mac][@"ip"];
+        if (!ip) continue;   // no address on record yet — nothing to route-block
+        [blocked addObject:@{ @"mac" : mac, @"ip" : ip }];
 
-            if (![previouslyBlocked containsObject:mac]) {
-                [newlyBlocked addObject:seen[mac][@"name"] ?: mac];
-            }
+        // Announce only a device the limit newly cut off, never a manual block.
+        if ([limitBlocked containsObject:mac] && ![previouslyBlocked containsObject:mac]) {
+            [newlyBlocked addObject:seen[mac][@"name"] ?: mac];
         }
     }
 
@@ -326,10 +385,12 @@ NSString *HPStatusReport(void) {
     [s appendFormat:@"\nSeen this period (%lu):\n", (unsigned long)seen.count];
     for (NSString *mac in seen) {
         NSDictionary *d = seen[mac];
-        [s appendFormat:@"  %-24s %-15s %-10s last %@\n",
+        [s appendFormat:@"  %-24s %-15s %-10s (down %@ / up %@) last %@\n",
                         [(d[@"name"] ?: mac) UTF8String],
                         [(d[@"ip"] ?: @"?") UTF8String],
                         [HPFormatBytes([d[@"bytes"] unsignedLongLongValue]) UTF8String],
+                        HPFormatBytes([d[@"down"] unsignedLongLongValue]),
+                        HPFormatBytes([d[@"up"] unsignedLongLongValue]),
                         d[@"last"] ? [fmt stringFromDate:d[@"last"]] : @"?"];
     }
 


### PR DESCRIPTION
## Summary
- Block a device from the hotspot: each device's page gets a *Block from Hotspot* switch, backed by a host reject route installed by the root daemon (reuses the existing per-device limit mechanism). Blocks clear on reboot/uninstall; a device that rejoins with a fresh randomised address is treated as new.
- Upload and download, split out: per-device pages and the overall usage pane now show Downloaded, Uploaded, and Total for the period, using the daemon's existing per-direction counts.
- Clearer device identity: devices with no DHCP name are labelled "Private Address" instead of a bare MAC, and every device page now shows an Identity section with both IP and MAC.
- Version bump to 0.7.0.
