### PR TITLE
Add 0.7.0 Sileo changelog and fix the manual-block reboot note

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ docs/      the generated APT repo, served by GitHub Pages
   Hotspot* switch: the root daemon installs a host reject route for that client,
   so it can no longer reach the internet through your hotspot. It stays joined to
   Wi-Fi (iOS exposes no way to force a client off the air), but nothing loads.
-  Turn it off to let it back on; blocks clear on reboot and on uninstall. A
-  device that rejoins with a fresh randomised Wi-Fi address is a new device and
-  is not still blocked. This reuses the same mechanism as the per-device limit.
+  Turn it off to let it back on — the block stays in place, across reboots
+  included, until you do, and is cleared on uninstall. A device that rejoins
+  with a fresh randomised Wi-Fi address is a new device and is not still
+  blocked. This reuses the same mechanism as the per-device limit.
 - **Upload and download, split out.** Every device's own page now shows
   Downloaded, Uploaded and Total for the period, and the usage pane shows the
   same split for the hotspot as a whole. The daemon's per-client tap counts each

--- a/web/depiction.json
+++ b/web/depiction.json
@@ -78,6 +78,11 @@
       "views": [
         {
           "class": "DepictionMarkdownView",
+          "markdown": "**0.7.0**\n• Block a device from your hotspot with a switch on its page — it stays on Wi-Fi but nothing loads, until you turn the block off\n• Usage split into Downloaded, Uploaded and Total, per device and for the hotspot overall\n• A device with no name of its own shows as \"Private Address\", and every device page lists its IP and MAC"
+        },
+        { "class": "DepictionSeparatorView" },
+        {
+          "class": "DepictionMarkdownView",
           "markdown": "**0.6.9**\n• Now installs and runs on iOS 18 — the crash behind the old block was the arm64e marker fixed in 0.6.7\n• The Buy Me a Beer 🍺 tip row is back, always shown"
         },
         { "class": "DepictionSeparatorView" },


### PR DESCRIPTION
## Summary

Two follow-up fixes after the 0.7.0 merge (#6), both docs/changelog only — no code changes.

- **`web/depiction.json`:** the 0.7.0 merge bumped `control` to 0.7.0 but left the Sileo changelog topping out at 0.6.9. `tools/repo-build.sh` requires the newest depiction entry to equal the control version, so `publish-release` would abort until this is added. This restores the match and gives Sileo a 0.7.0 changelog entry.
- **README:** the 0.7.0 changelog claimed a manual block "clears on reboot". It does not — a manual block is stored in the config plist, so the collector re-installs the reject route within seconds of every boot and it persists until switched off (or the tweak is uninstalled). Reworded to match the actual behaviour (which the in-app description already stated correctly).

## Why it matters

`publish-release` would fail the version guard exactly like the 0.6.9 incident, and the README would mislead users about how blocking behaves across reboots.

## Not included

No code changes. The 0.7.0 feature code from #6 is unchanged.