### PR TITLE
Add roothide package scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,13 @@ include $(THEOS)/makefiles/common.mk
 # write the same files. The roothide fork of Theos is required to build this.
 ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
 HP_SCHEME_LDFLAGS = -lroothide
+# Ad-hoc signing with no entitlements leaves the two tools unable to load
+# libroothide: dyld finds it and AMFI refuses it, errno 1, and launchd then
+# respawns the daemon every ThrottleInterval forever. platform-application is
+# what the bootstrap's own daemons carry, and it is what lifts that.
+HP_TOOL_CODESIGN = -Sroothide-entitlements.plist
+else
+HP_TOOL_CODESIGN = -S
 endif
 
 # TWO tweak dylibs, not one, and the split is deliberate.
@@ -82,7 +89,7 @@ hotspotpro_FILES = main.m Collector.m Prefs.m Tracker.m
 hotspotpro_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 hotspotpro_FRAMEWORKS = Foundation
 hotspotpro_LDFLAGS = $(HP_SCHEME_LDFLAGS)
-hotspotpro_CODESIGN_FLAGS = -S
+hotspotpro_CODESIGN_FLAGS = $(HP_TOOL_CODESIGN)
 
 # The per-device counter. Runs as root from a LaunchDaemon, so it installs to
 # libexec rather than bin — it is not meant to be run by hand.
@@ -90,7 +97,7 @@ hotspotprod_FILES = Daemon.m Collector.m Prefs.m
 hotspotprod_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 hotspotprod_FRAMEWORKS = Foundation
 hotspotprod_LDFLAGS = $(HP_SCHEME_LDFLAGS)
-hotspotprod_CODESIGN_FLAGS = -S
+hotspotprod_CODESIGN_FLAGS = $(HP_TOOL_CODESIGN)
 hotspotprod_INSTALL_PATH = /usr/libexec
 
 include $(THEOS_MAKE_PATH)/tool.mk

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,25 @@ TARGET := iphone:clang:latest:14.0
 # users' phones.
 ARCHS = arm64 arm64e
 
-# Rootless (/var/jb) unless HP_ROOTFUL=1 asks for a rootful package.
+# Rootless (/var/jb) unless HP_ROOTFUL=1 or HP_ROOTHIDE=1 asks for another one.
 # Deliberately not `?=`: with that, merely unsetting THEOS_PACKAGE_SCHEME still
 # left the default in place, so the "rootful" build quietly produced a second
 # rootless package that overwrote the first.
-ifneq ($(HP_ROOTFUL),1)
+ifeq ($(HP_ROOTHIDE),1)
+THEOS_PACKAGE_SCHEME = roothide
+else ifneq ($(HP_ROOTFUL),1)
 THEOS_PACKAGE_SCHEME = rootless
 endif
 
 include $(THEOS)/makefiles/common.mk
+
+# roothide installs under a directory whose name changes on every userspace
+# reboot, so the paths in Prefs.m are resolved through jbroot() at call time.
+# That lives in libroothide, which every product here needs: all four read or
+# write the same files. The roothide fork of Theos is required to build this.
+ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
+HP_SCHEME_LDFLAGS = -lroothide
+endif
 
 # TWO tweak dylibs, not one, and the split is deliberate.
 #
@@ -47,6 +57,7 @@ TWEAK_NAME = HotspotPro HotspotProSettings
 HotspotPro_FILES = SpringBoard.x Collector.m Prefs.m Tracker.m
 HotspotPro_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 HotspotPro_FRAMEWORKS = UIKit Foundation
+HotspotPro_LDFLAGS = $(HP_SCHEME_LDFLAGS)
 
 # Preferences: the UI. Filter in HotspotProSettings.plist. This is the only
 # product that may link Preferences.framework, where PSSpecifier and
@@ -61,6 +72,7 @@ HotspotProSettings_FILES = Settings.x Collector.m Prefs.m Tracker.m
 HotspotProSettings_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 HotspotProSettings_FRAMEWORKS = UIKit Foundation
 HotspotProSettings_PRIVATE_FRAMEWORKS = Preferences
+HotspotProSettings_LDFLAGS = $(HP_SCHEME_LDFLAGS)
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 
@@ -69,6 +81,7 @@ TOOL_NAME = hotspotpro hotspotprod
 hotspotpro_FILES = main.m Collector.m Prefs.m Tracker.m
 hotspotpro_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 hotspotpro_FRAMEWORKS = Foundation
+hotspotpro_LDFLAGS = $(HP_SCHEME_LDFLAGS)
 hotspotpro_CODESIGN_FLAGS = -S
 
 # The per-device counter. Runs as root from a LaunchDaemon, so it installs to
@@ -76,7 +89,14 @@ hotspotpro_CODESIGN_FLAGS = -S
 hotspotprod_FILES = Daemon.m Collector.m Prefs.m
 hotspotprod_CFLAGS = -fobjc-arc -Wno-deprecated-declarations
 hotspotprod_FRAMEWORKS = Foundation
+hotspotprod_LDFLAGS = $(HP_SCHEME_LDFLAGS)
 hotspotprod_CODESIGN_FLAGS = -S
 hotspotprod_INSTALL_PATH = /usr/libexec
 
 include $(THEOS_MAKE_PATH)/tool.mk
+
+# deb.mk reads the architecture out of control with `:=`, and that one names the
+# rootless arch, so this has to come after the include to take effect.
+ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
+THEOS_PACKAGE_ARCH := iphoneos-arm64e
+endif

--- a/layout/DEBIAN/postinst
+++ b/layout/DEBIAN/postinst
@@ -3,7 +3,8 @@
 #
 # The LaunchDaemon plist has to name an absolute path to the binary, and that
 # path differs between jailbreak types (/var/jb/usr/libexec on rootless, plain
-# /usr/libexec on rootful). dpkg does not rewrite file contents, so the plist is
+# /usr/libexec on rootful and on roothide, whose maintainer scripts already see
+# the jailbreak root as /). dpkg does not rewrite file contents, so the plist is
 # written here from the prefix that actually exists on this device rather than
 # shipped twice.
 

--- a/roothide-entitlements.plist
+++ b/roothide-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>platform-application</key>
+	<true/>
+	<key>com.apple.private.security.container-required</key>
+	<false/>
+</dict>
+</plist>

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -742,62 +742,53 @@ NSArray<NSDictionary *> *HPCopyPresentDevices(NSArray<NSString *> *hotspotIfName
 #pragma mark - Per-device bytes (from the daemon)
 
 NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceBytes(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDictionary *bytes = file[@"bytesByMac"];
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
 NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceUpload(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDictionary *bytes = file[@"uploadByMac"];
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
 NSDictionary<NSString *, NSNumber *> *HPCopyDaemonDeviceDownload(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDictionary *bytes = file[@"downloadByMac"];
     return [bytes isKindOfClass:[NSDictionary class]] ? bytes : @{};
 }
 
 NSDictionary *HPCopyDaemonStatus(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-daemon.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDaemonStatusPath()];
     return [file isKindOfClass:[NSDictionary class]] ? file : nil;
 }
 
 NSArray<NSString *> *HPDaemonBlockedMacs(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSArray *macs = file[@"installedBlocks"];
     return [macs isKindOfClass:[NSArray class]] ? macs : @[];
 }
 
 BOOL HPDaemonIsProbing(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     return [file[@"probing"] boolValue];
 }
 
 NSDate *HPDaemonTapSince(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDate *since = file[@"tapSince"];
     return [since isKindOfClass:[NSDate class]] ? since : nil;
 }
 
 NSDate *HPDaemonLastFlush(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDate *updated = file[@"updated"];
     return [updated isKindOfClass:[NSDate class]] ? updated : nil;
 }
 
 NSDictionary<NSString *, NSDate *> *HPCopyDaemonLastSeen(void) {
-    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:
-                              @"/var/mobile/Library/Caches/hotspotpro-devices.plist"];
+    NSDictionary *file = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
     NSDictionary *seen = file[@"lastSeenByMac"];
     return [seen isKindOfClass:[NSDictionary class]] ? seen : @{};
 }

--- a/src/Collector.m
+++ b/src/Collector.m
@@ -426,6 +426,7 @@ NSString *HPNormaliseMac(NSString *raw) {
 }
 
 NSArray<NSDictionary *> *HPCopyDhcpLeases(void) {
+    // iOS writes this one, so it is a real filesystem path under every scheme.
     NSString *path = @"/var/db/dhcpd_leases";
     NSString *text = [NSString stringWithContentsOfFile:path
                                                encoding:NSUTF8StringEncoding

--- a/src/Daemon.m
+++ b/src/Daemon.m
@@ -84,16 +84,6 @@ static NSMutableSet<NSString *> *gTouchedMacs;
 // after a bridge flap every per-client timestamp is stale at once, and a reader
 // that could not see the difference declared connected devices departed.
 static NSDate *gTapSince;
-static NSString *gDevicesPath = @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
-
-// A one-line breadcrumb saying what this process is doing, so the UI and CLI
-// can explain why per-device figures or blocking are absent instead of only
-// showing "helper not running". Written on startup and at each state change —
-// never in a tight loop — so it cannot become the 8,600-writes-a-day problem
-// the state file once was. Its absence means the binary never ran at all, which
-// is itself the answer (a LaunchDaemon that never bootstrapped, or a signature
-// the device refused to exec).
-static NSString *gStatusPath = @"/var/mobile/Library/Caches/hotspotpro-daemon.plist";
 
 // MAC -> IP for every block this daemon has installed. Declared here, up with
 // the other state, because the flush publishes its keys — it is read well
@@ -116,6 +106,14 @@ static void HPDaemonLog(NSString *format, ...) {
 
 /// Record what the daemon is doing right now. No-op when the state has not
 /// changed since the last call, so it is safe to call from inside the loop.
+///
+/// A one-line breadcrumb saying what this process is doing, so the UI and CLI
+/// can explain why per-device figures or blocking are absent instead of only
+/// showing "helper not running". Written on startup and at each state change —
+/// never in a tight loop — so it cannot become the 8,600-writes-a-day problem
+/// the state file once was. Its absence means the binary never ran at all, which
+/// is itself the answer (a LaunchDaemon that never bootstrapped, or a signature
+/// the device refused to exec).
 static void HPWriteDaemonStatus(NSString *state) {
     static NSString *last;
     if ([state isEqualToString:last]) return;
@@ -127,9 +125,10 @@ static void HPWriteDaemonStatus(NSString *state) {
             @"firmware" : [[NSProcessInfo processInfo] operatingSystemVersionString] ?: @"?",
             @"updated"  : [NSDate date],
         };
-        [payload writeToFile:gStatusPath atomically:YES];
+        NSString *statusPath = HPDaemonStatusPath();
+        [payload writeToFile:statusPath atomically:YES];
         [[NSFileManager defaultManager] setAttributes:@{ NSFilePosixPermissions : @0644 }
-                                         ofItemAtPath:gStatusPath error:NULL];
+                                         ofItemAtPath:statusPath error:NULL];
     } @catch (NSException *e) {
         HPDaemonLog(@"status write failed: %@", e);
     }
@@ -183,7 +182,8 @@ static void HPFlushCounters(void) {
         [gTouchedMacs removeAllObjects];
         HPPruneDevices();
 
-        NSString *tmp = [gDevicesPath stringByAppendingPathExtension:@"tmp"];
+        NSString *devicesPath = HPDevicesPath();
+        NSString *tmp = [devicesPath stringByAppendingPathExtension:@"tmp"];
         NSMutableDictionary *payload = [@{
             @"bytesByMac"   : gBytesByMac,
             @"uploadByMac"  : gUploadByMac,
@@ -208,11 +208,11 @@ static void HPFlushCounters(void) {
         [data writeToFile:tmp atomically:NO];
 
         NSFileManager *fm = [NSFileManager defaultManager];
-        [fm removeItemAtPath:gDevicesPath error:NULL];
-        [fm moveItemAtPath:tmp toPath:gDevicesPath error:NULL];
+        [fm removeItemAtPath:devicesPath error:NULL];
+        [fm moveItemAtPath:tmp toPath:devicesPath error:NULL];
         // Written by root, read by the tweak inside SpringBoard and Preferences.
         [fm setAttributes:@{ NSFilePosixPermissions : @0644 }
-             ofItemAtPath:gDevicesPath
+             ofItemAtPath:devicesPath
                     error:NULL];
     } @catch (NSException *e) {
         HPDaemonLog(@"flush failed: %@", e);
@@ -220,8 +220,6 @@ static void HPFlushCounters(void) {
 }
 
 #pragma mark - Blocking
-
-static NSString *gInstalledPath = @"/var/mobile/Library/Caches/hotspotpro-installed.plist";
 
 /// Install or remove a reject route for one hotspot client.
 ///
@@ -302,7 +300,7 @@ static void HPSweepHotspotRejectRoutes(void) {
 }
 
 static void HPSaveInstalledBlocks(void) {
-    [gInstalledBlocks writeToFile:gInstalledPath atomically:YES];
+    [gInstalledBlocks writeToFile:HPInstalledBlocksPath() atomically:YES];
 }
 
 /// Bring the routing table in line with the collector's blocklist.
@@ -372,13 +370,14 @@ static void HPDrainRouteSocket(int rs) {
 /// is torn down before we start — otherwise a device could stay cut off with
 /// nothing left that knows why.
 static void HPClearStaleBlocks(void) {
-    NSDictionary *stale = [NSDictionary dictionaryWithContentsOfFile:gInstalledPath];
+    NSString *installedPath = HPInstalledBlocksPath();
+    NSDictionary *stale = [NSDictionary dictionaryWithContentsOfFile:installedPath];
     if (![stale isKindOfClass:[NSDictionary class]] || stale.count == 0) return;
 
     HPDaemonLog(@"clearing %lu route block(s) left from a previous run",
                 (unsigned long)stale.count);
     for (NSString *mac in stale) HPSetRouteBlock(stale[mac], NO);
-    [[NSFileManager defaultManager] removeItemAtPath:gInstalledPath error:NULL];
+    [[NSFileManager defaultManager] removeItemAtPath:installedPath error:NULL];
 }
 
 #pragma mark - Capture
@@ -540,7 +539,7 @@ int main(int argc, char *argv[]) {
         // Counters survive a hotspot session; they are cumulative since the
         // daemon started, and the tweak turns them into per-period figures by
         // taking deltas (and treating a drop as a daemon restart).
-        NSDictionary *existing = [NSDictionary dictionaryWithContentsOfFile:gDevicesPath];
+        NSDictionary *existing = [NSDictionary dictionaryWithContentsOfFile:HPDevicesPath()];
         if ([existing[@"bytesByMac"] isKindOfClass:[NSDictionary class]]) {
             [gBytesByMac addEntriesFromDictionary:existing[@"bytesByMac"]];
             // Directional counters were added in 0.7.0; an older file has none,

--- a/src/Prefs.h
+++ b/src/Prefs.h
@@ -15,6 +15,12 @@ NSString *HPConfigPath(void);
 NSString *HPStatePath(void);
 NSString *HPLogPath(void);
 
+// The daemon's three files, named here rather than at each use so there is one
+// place to translate them for the package scheme.
+NSString *HPDevicesPath(void);
+NSString *HPDaemonStatusPath(void);
+NSString *HPInstalledBlocksPath(void);
+
 #pragma mark - Config
 
 // Config keys, all optional — HPConfig() applies defaults.

--- a/src/Prefs.m
+++ b/src/Prefs.m
@@ -55,6 +55,18 @@ NSString *HPBlocklistPath(void) {
     return @"/var/mobile/Library/Caches/hotspotpro-blocklist.plist";
 }
 
+NSString *HPDevicesPath(void) {
+    return @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
+}
+
+NSString *HPDaemonStatusPath(void) {
+    return @"/var/mobile/Library/Caches/hotspotpro-daemon.plist";
+}
+
+NSString *HPInstalledBlocksPath(void) {
+    return @"/var/mobile/Library/Caches/hotspotpro-installed.plist";
+}
+
 #pragma mark - Config
 
 NSDictionary *HPConfig(void) {

--- a/src/Prefs.m
+++ b/src/Prefs.m
@@ -1,6 +1,17 @@
 #import "Prefs.h"
 #include <notify.h>
 
+// roothide keeps the whole jailbreak filesystem inside a directory whose name is
+// randomised on every userspace reboot, so its paths are resolved at each call
+// rather than stored. The other schemes install at a fixed prefix and need no
+// translation.
+#if THEOS_PACKAGE_SCHEME_ROOTHIDE
+#import <roothide.h>
+#define HPJailbreakPath(path) jbroot(path)
+#else
+#define HPJailbreakPath(path) (path)
+#endif
+
 NSString *const HPCfgEnabledKey     = @"enabled";
 NSString *const HPCfgLimitGBKey     = @"limitGB";
 NSString *const HPCfgResetDayKey    = @"resetDay";
@@ -40,31 +51,31 @@ NSString *const HPStResetRequestKey = @"resetRequested";
 #pragma mark - Paths
 
 NSString *HPConfigPath(void) {
-    return @"/var/mobile/Library/Preferences/com.dangkhoa.hotspotpro.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Preferences/com.dangkhoa.hotspotpro.plist");
 }
 
 NSString *HPStatePath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro-state.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro-state.plist");
 }
 
 NSString *HPLogPath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro.log";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro.log");
 }
 
 NSString *HPBlocklistPath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro-blocklist.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro-blocklist.plist");
 }
 
 NSString *HPDevicesPath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro-devices.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro-devices.plist");
 }
 
 NSString *HPDaemonStatusPath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro-daemon.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro-daemon.plist");
 }
 
 NSString *HPInstalledBlocksPath(void) {
-    return @"/var/mobile/Library/Caches/hotspotpro-installed.plist";
+    return HPJailbreakPath(@"/var/mobile/Library/Caches/hotspotpro-installed.plist");
 }
 
 #pragma mark - Config


### PR DESCRIPTION
This adds roothide as a third package scheme alongside rootless and rootful. Build it with `make package HP_ROOTHIDE=1` using the roothide fork of Theos. The rootless and rootful packages come out the same as before.

There are three commits, and each message has the details:

- The daemon's three files (devices, status, installed blocks) become functions in `Prefs.m`, like the config, state, log and blocklist paths already are. Same strings, no behaviour change. This also covers the two readers 0.7.0 added for the upload/download split.
- roothide keeps the jailbreak root in a directory that gets renamed on every userspace reboot, so each path goes through `jbroot()` when it's used. That's one macro in `Prefs.m` and a no-op for the other schemes. `/var/db/dhcpd_leases` is iOS's own file and is left alone.
- On roothide the CLI and the daemon are signed with `platform-application`. Without it AMFI won't let them load libroothide (dyld fails with errno 1) and launchd keeps respawning the daemon. It's the same pair roothide Bootstrap's own daemons use.

Tested on roothide Bootstrap (ios16.3, iPhone 14 pro max): the Settings pane, the SpringBoard collector and the daemon all run, per-device counting works on bridge100, and each device shows its upload/download split. The rootless package builds clean for arm64 and arm64e, but I haven't installed it.

Unrelated, but worth mentioning: a manual block shows as blocked on the device page while the device keeps its connection. The daemon reports the route as installed, so I don't think it's roothide related. I'll open an issue once I've narrowed it down.
