### PR TITLE
Add a manual CI job to compile-check the roothide package

### DIFF
--- a/.github/workflows/build-roothide.yml
+++ b/.github/workflows/build-roothide.yml
@@ -1,0 +1,96 @@
+name: Build roothide (macOS)
+
+# Compile-check ONLY the roothide package. Deliberately separate from
+# build.yml, for two reasons:
+#
+#   1. roothide needs a different toolchain — the roothide fork of Theos, which
+#      is the only one that has the `roothide` package scheme and ships
+#      libroothide (for -lroothide and <roothide.h>). build.yml uses stock Theos.
+#   2. The stable channel does not ship a roothide deb, so this must never gate
+#      master. It runs on demand (workflow_dispatch) and just proves the roothide
+#      scheme still builds after a change to Prefs.m paths, the Makefile, etc.
+#
+# The arm64e ABI note from build.yml applies here too: only Xcode's linker on a
+# macOS runner emits the versioned ptrauth ABI that iOS actually loads.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-roothide:
+    runs-on: macos-14
+    env:
+      THEOS: ${{ github.workspace }}/theos-roothide
+      IOS_SDK: iPhoneOS16.5.sdk        # keep in step with build.yml
+      HP_TARGET: iphone:clang:16.5:14.0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packaging tools
+        run: brew install ldid dpkg
+
+      - name: Cache roothide Theos
+        id: theos
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.THEOS }}
+          key: theos-roothide-${{ env.IOS_SDK }}-v1
+
+      - name: Install roothide Theos
+        if: steps.theos.outputs.cache-hit != 'true'
+        run: |
+          # The roothide fork carries the roothide package scheme and libroothide.
+          git clone --recursive https://github.com/roothide/theos.git "$THEOS"
+          # One SDK, from the stock sdks repo — roothide builds against the normal
+          # iPhoneOS SDK; the fork only changes packaging, not the SDK.
+          mkdir -p "$THEOS/sdks"
+          git clone -n --depth 1 --filter=tree:0 https://github.com/theos/sdks.git /tmp/sdks
+          cd /tmp/sdks
+          git sparse-checkout set --no-cone "$IOS_SDK"
+          git checkout
+          mv "/tmp/sdks/$IOS_SDK" "$THEOS/sdks/$IOS_SDK"
+
+      - name: Check the toolchain and SDK
+        run: |
+          xcodebuild -version
+          ls -la "$THEOS/sdks"
+          test -d "$THEOS/sdks/$IOS_SDK/usr/include" \
+            || { echo "::error::$IOS_SDK is not laid out correctly under $THEOS/sdks"; exit 1; }
+          # libroothide is what -lroothide and <roothide.h> resolve against; if the
+          # fork did not vendor it, say so up front rather than in a link error.
+          ls "$THEOS"/vendor/lib/libroothide* "$THEOS"/vendor/include/roothide.h 2>/dev/null \
+            || echo "::warning::could not spot libroothide in \$THEOS/vendor — if the build fails to find -lroothide/<roothide.h>, that is why"
+
+      - name: Configure tip jar
+        env:
+          DONATE_URL: ${{ secrets.DONATE_URL }}
+        run: |
+          if [ -n "$DONATE_URL" ]; then
+            printf '%s' "$DONATE_URL" > donate-url.txt
+            echo "tip jar configured"
+          else
+            echo "no DONATE_URL secret set - the tip-jar row will be hidden"
+          fi
+
+      - name: Build the roothide package
+        run: bash tools/build-roothide.sh
+
+      - name: Surface the build log
+        if: failure()
+        run: |
+          LOG=build-roothide.log
+          [ -f "$LOG" ] || { echo "::error::build-roothide.log was never written"; exit 0; }
+          echo "::group::build-roothide.log (tail)"
+          tail -120 "$LOG"
+          echo "::endgroup::"
+          grep -i -E 'error:|fatal|\*\*\*|^ld:|not found|-lroothide|roothide.h' "$LOG" | tail -10 \
+            | sed 's/%/%25/g' | while IFS= read -r l; do echo "::error::$l"; done
+
+      - name: Upload the roothide deb
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-roothide
+          path: release-roothide/*.deb
+          if-no-files-found: warn

--- a/tools/build-roothide.sh
+++ b/tools/build-roothide.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Build ONLY the roothide package, for CI verification that the roothide scheme
+# still compiles. Kept separate from build-release.sh on purpose:
+#
+#   - roothide needs a DIFFERENT Theos (the roothide fork), because the stock
+#     Theos has no `roothide` package scheme and no libroothide for -lroothide /
+#     <roothide.h>. The caller points $THEOS at that fork.
+#   - The stable release channel does NOT ship a roothide deb; this only proves
+#     the build is not broken, so it is not wired into build-release.sh or the
+#     release pipeline.
+#
+# Mirrors build-release.sh's flat-copy-then-make dance and its arm64e ABI gate.
+# Run on a macOS runner: only Xcode's linker emits the versioned arm64e ABI iOS
+# actually loads (see build-release.sh for the long version).
+
+set -u
+export THEOS="${THEOS:-$HOME/theos}"
+
+if [ -d "$THEOS/toolchain/linux/host/bin" ]; then
+    export PATH="$THEOS/toolchain/linux/host/bin:$PATH"
+fi
+
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+LOG="$SRC/build-roothide.log"
+exec > >(tee "$LOG") 2>&1
+echo "=== roothide build started $(date) ==="
+echo "THEOS=$THEOS"
+
+WORK="$HOME/HotspotPro-roothide"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+# Sources live in src/ but land FLAT in the build dir, exactly as build-release.sh
+# does it — the Makefile names them bare on purpose.
+cp -f "$SRC"/src/*.m "$SRC"/src/*.h "$SRC"/src/*.x "$WORK"/ 2>/dev/null
+cp -f "$SRC"/Makefile "$SRC"/control "$SRC"/*.plist "$WORK"/ 2>/dev/null
+
+# The tip jar is optional for a compile check: Settings.x uses __has_include, so
+# a missing DonateURL.h just hides the row. Honour donate-url.txt if it is there.
+if [ -s "$SRC/donate-url.txt" ]; then
+    printf '#define HP_DONATE_URL "%s"\n' "$(cat "$SRC/donate-url.txt")" > "$WORK/DonateURL.h"
+    echo "tip jar: configured"
+else
+    rm -f "$WORK/DonateURL.h"
+    echo "tip jar: not configured, row will be hidden"
+fi
+cp -r "$SRC"/layout "$WORK"/
+chmod 755 "$WORK"/layout/DEBIAN/postinst "$WORK"/layout/DEBIAN/prerm
+
+OUT="$SRC/release-roothide"
+mkdir -p "$OUT"
+rm -f "$OUT"/*.deb
+
+cd "$WORK"
+rm -rf .theos packages
+
+# See build-release.sh: `latest` would pick Xcode's own SDK, which has no
+# PrivateFrameworks stubs and breaks the Settings link. Pin it when given.
+target=""
+if [ -n "${HP_TARGET:-}" ]; then
+    target="TARGET=$HP_TARGET"
+    echo "target: $HP_TARGET"
+fi
+
+# The Makefile forces THEOS_PACKAGE_ARCH := iphoneos-arm64e for this scheme, so
+# the control Architecture field is left alone — no sed dance like the other two.
+echo
+echo "=== make package HP_ROOTHIDE=1 ==="
+make package FINALPACKAGE=1 HP_ROOTHIDE=1 $target -j1
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "!! roothide build FAILED (exit $rc)"
+    exit $rc
+fi
+
+cp -f packages/*.deb "$OUT"/ 2>/dev/null
+if ! ls "$OUT"/*.deb >/dev/null 2>&1; then
+    echo "!! no roothide deb was produced"
+    exit 1
+fi
+
+echo
+echo "=== roothide artifact ==="
+ls -la "$OUT"
+for deb in "$OUT"/*.deb; do
+    echo "--- $(basename "$deb") ---"
+    dpkg-deb -f "$deb" Package Version Architecture Depends
+    echo "payload:"
+    dpkg-deb -c "$deb" | grep -E 'DynamicLibraries|libexec|usr/bin' | sed 's/^/  /'
+done
+
+# Same arm64e ABI gate as the release build: a deb that links and packages can
+# still carry the wrong ptrauth encoding, so verify the slices.
+echo
+echo "=== fat / ABI check ==="
+if ! bash "$SRC/tools/check-fat.sh" "$OUT"; then
+    echo "!! the roothide deb is NOT loadable — bad arm64e ABI"
+    exit 1
+fi
+
+echo
+echo "=== roothide build OK ==="


### PR DESCRIPTION
## Summary

Adds a **manual** CI job that compile-checks the roothide package (from PR #8), so a future change to `Prefs.m` paths, the `Makefile`, etc. can't silently break the roothide scheme.

- **`.github/workflows/build-roothide.yml`** — `workflow_dispatch`-only. Clones the roothide fork of Theos (the only one with the `roothide` scheme and `libroothide` for `-lroothide`/`<roothide.h>`; stock Theos in `build.yml` has neither) plus one iOS SDK, builds the roothide deb, runs the arm64e ABI check, and uploads the deb as an artifact.
- **`tools/build-roothide.sh`** — builds just the roothide scheme (`make … HP_ROOTHIDE=1`), mirroring `build-release.sh`'s flat-copy dance and its arm64e gate.

## Design notes

- **Never gates master.** The stable channel ships no roothide deb, so this is manual-run only — a red roothide toolchain setup can't turn the main build red.
- **Untested on a real runner** (no roothide toolchain available where this was written). The first real run may need a tweak; the most likely snag is `-lroothide`/`<roothide.h>` resolution, and the workflow prints a warning pointing at `$THEOS/vendor` if it can't find `libroothide`.

## How to use

After merge: **Actions → "Build roothide (macOS)" → Run workflow**.